### PR TITLE
feat: [ICH-4702] Add agent_version helm value for auto-update control…

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://app.entitle.io/favicon.ico
 # kmsType defaults to kubernetes_secret_manager, token/imageCredentials no longer required).
 # GCP platform field renamed from platform.gke to platform.gcp.
 # See DOPS-434 for full changelog.
-version: 2.3.0
+version: 2.4.0
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -167,3 +167,82 @@ Node selector
   {{- end -}}
 {{- end -}}
 
+{{/* Auto-update helper functions */}}
+
+{{/* Extracts "autoUpdate" field from token */}}
+{{- define "entitle-agent.extractedAutoUpdate" -}}
+  {{- include "entitle-agent.extractTokenField" (dict "token" (include "entitle-agent.getToken" .) "field" "autoUpdate") -}}
+{{- end -}}
+
+{{/*
+Validates agent_version + image.tag compatibility. Fails helm install on incompatible combos.
+*/}}
+{{- define "entitle-agent.validateAgentVersion" -}}
+  {{- $imageTag := .Values.agent.image.tag | default "latest" -}}
+  {{- $agentVersion := .Values.agent.agent_version | default "default" -}}
+  {{- $isLatest := eq $imageTag "latest" -}}
+  {{- $isKnownKeyword := or (eq $agentVersion "default") (eq $agentVersion "auto-update") (eq $agentVersion "latest-on-restart") -}}
+
+  {{- if not $isLatest -}}
+    {{- if or (eq $agentVersion "auto-update") (eq $agentVersion "latest-on-restart") -}}
+      {{- fail (printf "You can't set agent_version='%s' with a manually set value for agent.image.tag. Please unset agent.image.tag." $agentVersion) -}}
+    {{- end -}}
+    {{- if not $isKnownKeyword -}}
+      {{- fail "You can't set both agent_version and agent.image.tag, please unset agent.image.tag." -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Resolves the effective image tag based on agent_version and image.tag.
+  - Custom image.tag (non-latest) + default => custom tag (legacy)
+  - latest + keyword (default/auto-update/latest-on-restart) => latest
+  - latest + hardcoded version (e.g. 2.7.4) => that version
+*/}}
+{{- define "entitle-agent.resolvedImageTag" -}}
+  {{- $imageTag := .Values.agent.image.tag | default "latest" -}}
+  {{- $agentVersion := .Values.agent.agent_version | default "default" -}}
+  {{- $isLatest := eq $imageTag "latest" -}}
+  {{- $isKnownKeyword := or (eq $agentVersion "default") (eq $agentVersion "auto-update") (eq $agentVersion "latest-on-restart") -}}
+
+  {{- if not $isLatest -}}
+    {{- $imageTag -}}
+  {{- else if $isKnownKeyword -}}
+    {{- "latest" -}}
+  {{- else -}}
+    {{- $agentVersion -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Resolves restart policy: "always" or "never".
+  - Custom image.tag (non-latest) => never
+  - default + autoUpdate missing/v0 => never
+  - default + autoUpdate v1 => always
+  - latest-on-restart => never
+  - auto-update => always
+  - hardcoded version => never
+*/}}
+{{- define "entitle-agent.resolvedRestartPolicy" -}}
+  {{- $imageTag := .Values.agent.image.tag | default "latest" -}}
+  {{- $agentVersion := .Values.agent.agent_version | default "default" -}}
+  {{- $isLatest := eq $imageTag "latest" -}}
+  {{- $autoUpdate := include "entitle-agent.extractedAutoUpdate" . -}}
+
+  {{- if not $isLatest -}}
+    {{- "never" -}}
+  {{- else if eq $agentVersion "auto-update" -}}
+    {{- "always" -}}
+  {{- else if eq $agentVersion "latest-on-restart" -}}
+    {{- "never" -}}
+  {{- else if eq $agentVersion "default" -}}
+    {{- if eq $autoUpdate "v1" -}}
+      {{- "always" -}}
+    {{- else -}}
+      {{- "never" -}}
+    {{- end -}}
+  {{- else -}}
+    {{- "never" -}}
+  {{- end -}}
+{{- end -}}
+

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -209,6 +209,12 @@ healthcheck init container so validators run with identical configuration.
   value: {{ include "entitle-agent.proxyUrl" . | quote }}
 - name: ENTITLE_MAX_ROUTING_VERSION
   value: "v1"
+- name: HELM_AGENT_VERSION
+  value: {{ .Values.agent.agent_version | default "default" | quote }}
+- name: HELM_AGENT_IMAGE_TAG
+  value: {{ include "entitle-agent.resolvedImageTag" . | quote }}
+- name: HELM_RESTART_POLICY
+  value: {{ include "entitle-agent.resolvedRestartPolicy" . | quote }}
 {{- if eq .Values.kmsType "hashicorp_vault" }}
 - name: HASHICORP_VAULT_CONNECTION_STRING
   valueFrom:
@@ -237,3 +243,84 @@ healthcheck init container so validators run with identical configuration.
   value: "true"
 {{- end }}
 {{- end }}
+
+{{/* ============================================================
+     Auto-update helper functions
+     ============================================================ */}}
+
+{{/* Extracts "autoUpdate" field from token */}}
+{{- define "entitle-agent.extractedAutoUpdate" -}}
+  {{- include "entitle-agent.extractTokenField" (dict "token" (include "entitle-agent.getToken" .) "field" "autoUpdate") -}}
+{{- end -}}
+
+{{/*
+Validates agent_version + image.tag compatibility. Fails helm install on incompatible combos.
+*/}}
+{{- define "entitle-agent.validateAgentVersion" -}}
+  {{- $imageTag := .Values.agent.image.tag | default "latest" -}}
+  {{- $agentVersion := .Values.agent.agent_version | default "default" -}}
+  {{- $isLatest := eq $imageTag "latest" -}}
+  {{- $isKnownKeyword := or (eq $agentVersion "default") (eq $agentVersion "auto-update") (eq $agentVersion "latest-on-restart") -}}
+
+  {{- if not $isLatest -}}
+    {{- if or (eq $agentVersion "auto-update") (eq $agentVersion "latest-on-restart") -}}
+      {{- fail (printf "You can't set agent_version='%s' with a manually set value for agent.image.tag. Please unset agent.image.tag." $agentVersion) -}}
+    {{- end -}}
+    {{- if not $isKnownKeyword -}}
+      {{- fail "You can't set both agent_version and agent.image.tag, please unset agent.image.tag." -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Resolves the effective image tag based on agent_version and image.tag.
+  - Custom image.tag (non-latest) + default => custom tag (legacy)
+  - latest + keyword (default/auto-update/latest-on-restart) => latest
+  - latest + hardcoded version (e.g. 2.7.4) => that version
+*/}}
+{{- define "entitle-agent.resolvedImageTag" -}}
+  {{- $imageTag := .Values.agent.image.tag | default "latest" -}}
+  {{- $agentVersion := .Values.agent.agent_version | default "default" -}}
+  {{- $isLatest := eq $imageTag "latest" -}}
+  {{- $isKnownKeyword := or (eq $agentVersion "default") (eq $agentVersion "auto-update") (eq $agentVersion "latest-on-restart") -}}
+
+  {{- if not $isLatest -}}
+    {{- $imageTag -}}
+  {{- else if $isKnownKeyword -}}
+    {{- "latest" -}}
+  {{- else -}}
+    {{- $agentVersion -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Resolves restart policy: "always" or "never".
+  - Custom image.tag (non-latest) => never
+  - default + autoUpdate missing/v0 => never
+  - default + autoUpdate v1 => always
+  - latest-on-restart => never
+  - auto-update => always
+  - hardcoded version => never
+*/}}
+{{- define "entitle-agent.resolvedRestartPolicy" -}}
+  {{- $imageTag := .Values.agent.image.tag | default "latest" -}}
+  {{- $agentVersion := .Values.agent.agent_version | default "default" -}}
+  {{- $isLatest := eq $imageTag "latest" -}}
+  {{- $autoUpdate := include "entitle-agent.extractedAutoUpdate" . -}}
+
+  {{- if not $isLatest -}}
+    {{- "never" -}}
+  {{- else if eq $agentVersion "auto-update" -}}
+    {{- "always" -}}
+  {{- else if eq $agentVersion "latest-on-restart" -}}
+    {{- "never" -}}
+  {{- else if eq $agentVersion "default" -}}
+    {{- if eq $autoUpdate "v1" -}}
+      {{- "always" -}}
+    {{- else -}}
+      {{- "never" -}}
+    {{- end -}}
+  {{- else -}}
+    {{- "never" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/entitle-agent/templates/deployment.yaml
+++ b/charts/entitle-agent/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "entitle-agent.validateAgentVersion" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +47,13 @@ spec:
           value: {{ include "entitle-agent.proxyUrl" . | quote }}
         - name: ENTITLE_MAX_ROUTING_VERSION
           value: "v1"
+        # Auto-update configuration (from agent_version helm value + token autoUpdate field)
+        - name: HELM_AGENT_VERSION
+          value: {{ .Values.agent.agent_version | default "default" | quote }}
+        - name: HELM_AGENT_IMAGE_TAG
+          value: {{ include "entitle-agent.resolvedImageTag" . | quote }}
+        - name: HELM_RESTART_POLICY
+          value: {{ include "entitle-agent.resolvedRestartPolicy" . | quote }}
         {{- if eq .Values.kmsType "hashicorp_vault" }}
         - name: HASHICORP_VAULT_CONNECTION_STRING
           valueFrom:
@@ -73,7 +81,7 @@ spec:
         - name: ENTITLE_LOG_TO_FILE
           value: "true"
         {{- end }}
-        image: {{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}
+        image: {{ .Values.agent.image.repository }}:{{ include "entitle-agent.resolvedImageTag" . }}
         imagePullPolicy: Always
         name: {{ include "entitle-agent.fullname" . }}
         {{- with .Values.agent.resources }}

--- a/charts/entitle-agent/templates/deployment.yaml
+++ b/charts/entitle-agent/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "entitle-agent.validateAgentVersion" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,7 +83,7 @@ spec:
       # Healthcheck validators must exit 0 before the main agent container starts.
       # This guarantees the agent never consumes Kafka messages in an invalid state.
       - name: {{ include "entitle-agent.fullname" . }}-healthcheck
-        image: {{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}
+        image: {{ .Values.agent.image.repository }}:{{ include "entitle-agent.resolvedImageTag" . }}
         imagePullPolicy: Always
         command:
           - python
@@ -100,7 +101,7 @@ spec:
         {{- end }}
       containers:
       - name: {{ include "entitle-agent.fullname" . }}
-        image: {{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}
+        image: {{ .Values.agent.image.repository }}:{{ include "entitle-agent.resolvedImageTag" . }}
         imagePullPolicy: Always
         env:
         {{- include "entitle-agent.agentEnv" . | nindent 8 }}

--- a/charts/entitle-agent/values.schema.json
+++ b/charts/entitle-agent/values.schema.json
@@ -197,6 +197,10 @@
             "repository",
             "tag"
           ]
+        },
+        "agent_version": {
+          "type": "string",
+          "default": "default"
         }
       }
     }

--- a/charts/entitle-agent/values.schema.json
+++ b/charts/entitle-agent/values.schema.json
@@ -209,6 +209,11 @@
               "description": "Kafka public bootstrap servers (optional)"
             }
           }
+        },
+        "agent_version": {
+          "type": "string",
+          "default": "default",
+          "description": "Controls image tag + restart policy. Valid: default, latest-on-restart, auto-update, or a pinned semver (e.g. 2.7.4)."
         }
       }
     },

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -38,6 +38,7 @@ agent:
   image:
     repository: ghcr.io/anycred/entitle-agent  # Docker image repository
     tag: latest  # Tag for docker image of agent
+  agent_version: "default"  # Controls image tag + restart policy. Valid: default, latest-on-restart, auto-update, or a pinned version (e.g. 2.7.4)
 
   replicas: 3  # Number of pods to run
   resources:

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -100,6 +100,11 @@ agent:
     repository: ghcr.io/anycred/entitle-agent  # Docker image repository
     tag: latest            # Tag for the agent image; defaults to Chart.appVersion if empty
 
+  # -- agent_version: Controls the effective image tag + restart policy.
+  # Valid: "default" (token-controlled), "auto-update", "latest-on-restart", or a pinned semver (e.g. "2.7.4").
+  # See docs: https://docs.beyondtrust.com/entitle/docs/entitle-agent
+  agent_version: "default"
+
   replicas: 3              # Number of agent pods
 
   resources:


### PR DESCRIPTION
… (Phase 2)

Add agent_version input that controls restart policy and image tag resolution. Supports: default (token-controlled), auto-update, latest-on-restart, or pinned version. Validates incompatible combinations with agent.image.tag at install time. Deploys HELM_AGENT_VERSION, HELM_AGENT_IMAGE_TAG, HELM_RESTART_POLICY env vars.