### PR TITLE
feat(chart): auto-extract imageCredentials from token, add imagePullSecret.existingSecret

### DIFF
--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -167,3 +167,31 @@ Node selector
   {{- end -}}
 {{- end -}}
 
+{{/*
+Image pull secret name — resolves to the appropriate imagePullSecret.
+Returns imagePullSecret.existingSecret if set (for GitOps/ESO workflows),
+otherwise falls back to the chart-managed docker-login secret name.
+Used by: deployment.yaml (imagePullSecrets)
+*/}}
+{{- define "entitle-agent.imagePullSecretName" -}}
+{{- if .Values.imagePullSecret.existingSecret -}}
+{{- .Values.imagePullSecret.existingSecret -}}
+{{- else -}}
+{{- include "entitle-agent.fullname" . }}-docker-login
+{{- end -}}
+{{- end }}
+
+{{/*
+Auto-extract imageCredentials from the agent token blob.
+The token is a base64-encoded JSON containing multiple fields, including
+imageCredentials (a dockerconfigjson for pulling the agent image).
+This helper decodes and extracts it so customers don't need to provide
+imageCredentials separately — just pass agent.token and the chart handles the rest.
+Used by: docker-login.yaml (conditional image pull secret creation)
+*/}}
+{{- define "entitle-agent.imageCredentialsFromToken" -}}
+{{- if .Values.agent.token -}}
+{{- (b64dec .Values.agent.token | fromJson).imageCredentials -}}
+{{- end -}}
+{{- end }}
+

--- a/charts/entitle-agent/templates/deployment.yaml
+++ b/charts/entitle-agent/templates/deployment.yaml
@@ -141,8 +141,12 @@ spec:
             mountPath: /var/log/entitle-agent
             readOnly: true
       {{- end }}
+      {{- /* Use existingSecret if set, otherwise use chart-managed secret (only if credentials are available) */ -}}
+      {{- $imageCreds := .Values.imageCredentials | default (include "entitle-agent.imageCredentialsFromToken" .) -}}
+      {{- if or .Values.imagePullSecret.existingSecret $imageCreds }}
       imagePullSecrets:
-        - name: {{ include "entitle-agent.fullname" . }}-docker-login
+        - name: {{ include "entitle-agent.imagePullSecretName" . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/entitle-agent/templates/docker-login.yaml
+++ b/charts/entitle-agent/templates/docker-login.yaml
@@ -1,9 +1,21 @@
+{{/*
+Docker registry login secret.
+Priority chain for image pull credentials:
+  1. imagePullSecret.existingSecret — reference a pre-existing Secret (for GitOps/ESO)
+  2. imageCredentials (explicit) — override value passed via --set
+  3. Auto-extracted from agent.token blob — the token contains imageCredentials inside it
+If none of the above are set, no docker-login Secret is created and imagePullSecrets
+is omitted from the Deployment (useful when nodes already have registry access).
+*/}}
+{{- $imageCreds := .Values.imageCredentials | default (include "entitle-agent.imageCredentialsFromToken" .) -}}
+{{- if $imageCreds }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "entitle-agent.fullname" . }}-docker-login
   labels:
-  {{- include "entitle-agent.labels" . | nindent 4 }}
+    {{- include "entitle-agent.labels" . | nindent 4 }}
 data:
-  .dockerconfigjson: {{ required "imageCredentials are required (via token or --set)" (include "entitle-agent.imageCredentials" .) | quote }}
+  .dockerconfigjson: {{ $imageCreds | quote }}
 type: kubernetes.io/dockerconfigjson
+{{- end }}

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -4,6 +4,13 @@
 
 imageCredentials: "MISSING_CUSTOMER_DATA"  # Credentials you've received upon agent installation (Contact us for more info)
 
+# imagePullSecret -- Alternative to imageCredentials: reference a pre-existing
+# kubernetes.io/dockerconfigjson Secret in the cluster for pulling the agent image.
+# Use this for GitOps workflows where secrets are managed by External Secrets Operator,
+# Sealed Secrets, or similar tools. When set, imageCredentials is ignored.
+imagePullSecret:
+  existingSecret: ""  # Name of existing Secret (e.g. "my-registry-credentials")
+
 platform:
   mode: "native"  # Cloud platform where Entitle is installed (Contact us for more info)
   aws:


### PR DESCRIPTION
## Summary

- Removes the `required` render-time guard from `docker-login.yaml` — `helm template` no longer fails without `imageCredentials`
- Auto-extracts `imageCredentials` from the base64-encoded `agent.token` blob using Helm's `b64dec | fromJson`
- Adds `imagePullSecret.existingSecret` for GitOps/ESO workflows where secrets are managed outside Helm
- Priority chain: `imagePullSecret.existingSecret` > explicit `imageCredentials` > auto-extracted from `agent.token` > none

**Before:** customers had to decode the token blob, extract imageCredentials, and pass both separately
**After:** `helm install --set agent.token=<blob>` is all that's needed

**Jira:** DOPS-567 | **Epic:** DOPS-434

> **Note:** This branch includes helper templates also present in DOPS-566. Merge DOPS-566 first, then rebase this branch to resolve trivial conflicts in `_helpers.tpl`.

## Test plan
- [ ] `helm lint` passes with only `agent.token` set (no `imageCredentials`)
- [ ] `helm lint` passes with `imagePullSecret.existingSecret` set
- [ ] `helm template` with `imagePullSecret.existingSecret` shows correct secret reference
- [ ] `helm template` without any credentials omits `imagePullSecrets` from Deployment
- [ ] Backwards-compatible: `helm lint` still works with explicit `imageCredentials`

🤖 Generated with [Claude Code](https://claude.com/claude-code)