### PR TITLE
fix(chart): standardize labels via named templates, bump to v2.0.0

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -22,7 +22,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+# Breaking change: defaults changed (MISSING_CUSTOMER_DATA removed, kmsType defaults
+# to kubernetes_secret_manager, token/imageCredentials no longer required).
+# See DOPS-434 for full changelog.
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/entitle-agent/templates/deployment.yaml
+++ b/charts/entitle-agent/templates/deployment.yaml
@@ -3,12 +3,11 @@ kind: Deployment
 metadata:
   name: {{ include "entitle-agent.fullname" . }}
   labels:
-    app: {{ include "entitle-agent.fullname" . }}
+    {{- include "entitle-agent.labels" . | nindent 4 }}
     environment: {{ .Values.global.environment }}
     tags.datadoghq.com/env: {{ .Values.global.environment }}
     tags.datadoghq.com/service: {{ include "entitle-agent.fullname" . }}-{{ .Values.global.environment }}
-    tags.datadoghq.com/version: {{ include "entitle-agent.imageTag" .}}
-    {{- include "entitle-agent.labels" . | nindent 4 }}
+    tags.datadoghq.com/version: {{ include "entitle-agent.imageTag" . }}
 spec:
   replicas: {{ .Values.agent.replicas }}
   selector:
@@ -25,12 +24,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: {{ include "entitle-agent.fullname" . }}
+        {{- include "entitle-agent.selectorLabels" . | nindent 8 }}
         environment: {{ .Values.global.environment }}
         tags.datadoghq.com/env: {{ .Values.global.environment }}
         tags.datadoghq.com/service: {{ include "entitle-agent.fullname" . }}-{{ .Values.global.environment }}
-        tags.datadoghq.com/version: {{ include "entitle-agent.imageTag" .}}
-        {{- include "entitle-agent.selectorLabels" . | nindent 8 }}
+        tags.datadoghq.com/version: {{ include "entitle-agent.imageTag" . }}
         {{- if eq .Values.platform.mode "azure" }}
         azure.workload.identity/use: "true"
         {{- end }}


### PR DESCRIPTION
## Summary

- Removes raw `app: entitle-agent` labels from Deployment metadata and pod template
- All standard labels now flow from `entitle-agent.labels` and `entitle-agent.selectorLabels` named templates — single source of truth
- Datadog Unified Service Tagging labels remain as additive labels
- Bumps chart version to `2.0.0` (breaking: defaults changed across DOPS-434 epic)

**Jira:** DOPS-570 | **Epic:** DOPS-434

> **Merge order:** This should be merged **last** — the version bump signals the complete v2.0.0 release including all DOPS-434 changes.

## Test plan
- [x] `helm lint` passes
- [ ] `helm template` output has correct labels from named templates
- [ ] `spec.selector.matchLabels` still matches pod template labels
- [ ] Chart.yaml shows version 2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)