### PR TITLE
ci: enable ct install tests with kind cluster, add auto chart version bump

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,8 +1,17 @@
+# =============================================================================
+# Lint and Test Charts
+# =============================================================================
+# Runs on every push to any branch:
+#   1. Lint changed charts (yamllint + Yamale schema validation)
+#   2. Spin up a kind cluster and run ct install (real Helm install smoke test)
+#
+# The install test uses charts/entitle-agent/ci/default-values.yaml which
+# exercises the existingSecret path — no real credentials needed.
+# =============================================================================
 name: Lint and Test Charts
 
 on:
   workflow_dispatch:
-
   push:
     branches: [ '**' ]
 
@@ -20,8 +29,7 @@ jobs:
         with:
           version: v3.12.1
 
-      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
-      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      # Python is required because ct lint runs Yamale and yamllint
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
@@ -42,9 +50,20 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --config ct.yaml
 
-#      - name: Create kind cluster
-#        uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478 # v1.2.0
-#        if: steps.list-changed.outputs.changed == 'true'
+      # Spin up a kind cluster for install testing.
+      # ct install uses ci/*.yaml values files automatically.
+      - name: Create kind cluster
+        uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478 # v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
 
-#      - name: Run chart-testing (install)
-#        run: ct install --config ct.yaml
+      - name: Add dependency chart repos
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helm repo add datadog https://helm.datadoghq.com
+          helm repo update
+
+      # Install test: validates templates render correctly and Helm install succeeds.
+      # Pods will be Pending (existingSecret refs don't exist in kind) — that's expected.
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --config ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,12 @@
+# =============================================================================
+# Release Charts
+# =============================================================================
+# Triggered on push to master (after PR merge) or manual dispatch.
+#
+# Auto-bumps the chart patch version if the current version was already released
+# (prevents silent failures when developers forget to bump Chart.yaml).
+# Then runs chart-releaser to publish to GitHub Pages.
+# =============================================================================
 name: Release Charts
 
 on:
@@ -5,7 +14,6 @@ on:
   push:
     branches:
       - master
-    tags:
 
 jobs:
   release:
@@ -34,6 +42,29 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add datadog https://helm.datadoghq.com
+
+      # Auto-bump: if the current chart version already has a release tag,
+      # increment the patch version so chart-releaser has something new to publish.
+      # This prevents silent failures when developers forget to bump Chart.yaml.
+      - name: Bump chart patch version if already released
+        run: |
+          CHART_FILE="charts/entitle-agent/Chart.yaml"
+          CURRENT=$(grep '^version:' "$CHART_FILE" | awk '{print $2}')
+          echo "Current chart version: ${CURRENT}"
+
+          # Check if a release tag already exists for this version
+          if git tag | grep -q "entitle-agent-${CURRENT}$"; then
+            echo "Version ${CURRENT} already released — bumping patch version"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            NEW="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            sed -i "s/^version: .*/version: ${NEW}/" "$CHART_FILE"
+            echo "Bumped to ${NEW}"
+            git add "$CHART_FILE"
+            git commit -m "chore(release): bump entitle-agent chart to ${NEW} [skip ci]"
+            git push
+          else
+            echo "Version ${CURRENT} not yet released — proceeding without bump"
+          fi
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0

--- a/charts/entitle-agent/ci/default-values.yaml
+++ b/charts/entitle-agent/ci/default-values.yaml
@@ -1,0 +1,39 @@
+# =============================================================================
+# Chart Testing (ct install) — minimal values for install smoke test
+# =============================================================================
+# This file is automatically used by `ct install` to validate that the chart
+# installs successfully in a kind cluster. It uses the existingSecret path
+# so no real credentials are needed.
+#
+# The pod will not start (the referenced secrets don't exist in the test cluster),
+# but Helm install succeeds — which is what we're validating here.
+# =============================================================================
+
+kmsType: kubernetes_secret_manager
+
+platform:
+  mode: native
+
+agent:
+  # Reference a non-existent secret — install succeeds, pod stays Pending (expected)
+  existingSecret: entitle-agent-secret-ci
+  image:
+    repository: busybox   # Lightweight image for CI — agent won't actually run
+    tag: latest
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+# Reference a non-existent image pull secret — install still succeeds
+imagePullSecret:
+  existingSecret: entitle-registry-ci
+
+# Disable Datadog entirely for CI — avoids pulling the subchart dependency
+datadog:
+  enabled: false
+  sidecarLogs: false


### PR DESCRIPTION
## Summary

- **Install smoke test:** Creates `ci/default-values.yaml` and enables `ct install` in the lint-test workflow. Spins up a kind cluster and validates that `helm install` succeeds. Uses `existingSecret` path so no real credentials are needed.
- **Auto version bump:** Adds a step to the release workflow that auto-increments the patch version if the current version was already released. Prevents silent failures when developers forget to bump `Chart.yaml`.
- **Documentation:** All workflow steps have comments explaining their purpose.

**Jira:** DOPS-571 | **Epic:** DOPS-434

## Test plan
- [ ] `helm lint -f ci/default-values.yaml` passes locally
- [ ] lint-test workflow runs on PR push (check Actions tab)
- [ ] CI values file disables Datadog to avoid subchart dependency issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)