### PR TITLE
revert(chart): revert v2.1.0 lookup changes, bump to v2.1.1

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://app.entitle.io/favicon.ico
 # kmsType defaults to kubernetes_secret_manager, token/imageCredentials no longer required).
 # GCP platform field renamed from platform.gke to platform.gcp.
 # See DOPS-434 for full changelog.
-version: 2.1.0
+version: 2.0.0
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://app.entitle.io/favicon.ico
 # kmsType defaults to kubernetes_secret_manager, token/imageCredentials no longer required).
 # GCP platform field renamed from platform.gke to platform.gcp.
 # See DOPS-434 for full changelog.
-version: 2.0.0
+version: 2.1.1
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/README.md
+++ b/charts/entitle-agent/README.md
@@ -35,11 +35,9 @@ helm upgrade --install entitle-agent entitle/entitle-agent \
 
 > `kmsType` defaults to `kubernetes_secret_manager` — only set it if you need a different KMS (e.g., `aws_secret_manager`, `gcp_secret_manager`, `azure_secret_manager`, `hashicorp_vault`).
 
-### Scenario 2 — Pre-existing Secret (GitOps / External Secrets)
+### Scenario 2 — Pre-existing Secret (Single Value)
 
-Reference a pre-existing Kubernetes Secret. The chart reads the secret at deploy time using Helm `lookup`, extracts `imageCredentials` and `datadogApiKey`, and creates the docker-login and Datadog secrets as regular chart resources — fully tracked by ArgoCD.
-
-> **Important:** The referenced secret must exist in the namespace **before** deploying the chart. If you use External Secrets Operator, ensure the ExternalSecret is deployed and reconciled first (e.g., via a Helm pre-install hook in a wrapper chart, or a separate ArgoCD Application).
+Reference a pre-existing Kubernetes Secret. A pre-install hook automatically extracts `imageCredentials` and `datadogApiKey` from the token inside the Secret — no additional configuration needed.
 
 **Step 1 — Create the Secret:**
 
@@ -49,7 +47,7 @@ kubectl create secret generic entitle-agent-token \
   -n entitle
 ```
 
-Or as YAML (for External Secrets Operator, Sealed Secrets, etc.):
+Or as YAML:
 
 ```yaml
 apiVersion: v1
@@ -61,6 +59,8 @@ stringData:
   ENTITLE_JSON_CONFIGURATION: '{"BASE64_CONFIGURATION":"<your-token>"}'
 ```
 
+This works with any secret management tool — External Secrets Operator, Sealed Secrets, HashiCorp Vault, or plain `kubectl`.
+
 **Step 2 — Install the chart:**
 
 ```bash
@@ -69,11 +69,18 @@ helm upgrade --install entitle-agent entitle/entitle-agent \
   -n entitle --create-namespace
 ```
 
-The chart automatically extracts and creates:
-- `entitle-agent-docker-login` (image pull credentials)
-- `entitle-agent-datadog-secret` (Datadog API key)
+### Scenario 3 — Pre-existing Secret + Own Registry
 
-### Scenario 3 — Explicit Override (Backwards-Compatible)
+If you manage your own image pull secret separately:
+
+```bash
+helm upgrade --install entitle-agent entitle/entitle-agent \
+  --set agent.secretRef.name="entitle-agent-token" \
+  --set imagePullSecret.name="my-registry-secret" \
+  -n entitle --create-namespace
+```
+
+### Scenario 4 — Explicit Override (Backwards-Compatible)
 
 If you have existing automation that passes credentials explicitly, this still works:
 

--- a/charts/entitle-agent/ci/integration-test.sh
+++ b/charts/entitle-agent/ci/integration-test.sh
@@ -203,9 +203,9 @@ fi
 echo ""
 
 # ==========================================================================
-# TEST 2: SecretRef (lookup extracts imageCredentials from pre-existing secret)
+# TEST 2: SecretRef only (hook extracts everything)
 # ==========================================================================
-info "TEST 2: SecretRef (chart extracts imageCredentials via lookup)"
+info "TEST 2: SecretRef only (hook extracts imageCredentials + datadogApiKey)"
 cleanup
 kubectl create namespace "$NAMESPACE"
 
@@ -218,11 +218,12 @@ helm install "$RELEASE" "./$CHART_DIR" \
   -f "${CI_DIR}/test-secretref-only.yaml" \
   -n "$NAMESPACE" --wait=false
 
-# Verify chart created docker-login via lookup (extracted from token in pre-existing secret)
+# Verify hook-created secrets
+sleep 10  # give hook time to run
 if check_secret_exists "entitle-agent-docker-login"; then
-  pass "Test 2: docker-login secret created (extracted via lookup)"
+  pass "Test 2: docker-login secret created by hook"
 else
-  fail "Test 2: docker-login secret NOT created"
+  fail "Test 2: docker-login secret NOT created by hook"
 fi
 
 # Verify the chart did NOT create entitle-agent-secret (no token in values)
@@ -239,9 +240,9 @@ else
   fail "Test 2: agent pod NOT running"
 fi
 
-# Verify imagePullSecrets references the chart-created docker-login
+# Verify imagePullSecrets references the hook-created secret
 if check_deployment_image_pull_secret "entitle-agent-docker-login"; then
-  pass "Test 2: imagePullSecrets correct"
+  pass "Test 2: imagePullSecrets correct (hook-created)"
 else
   fail "Test 2: imagePullSecrets incorrect"
 fi
@@ -249,7 +250,7 @@ fi
 echo ""
 
 # ==========================================================================
-# TEST 3: SecretRef + own registry (user provides imagePullSecret.name)
+# TEST 3: SecretRef + own registry (hook extracts datadogApiKey only)
 # ==========================================================================
 info "TEST 3: SecretRef + own registry (user provides imagePullSecret)"
 cleanup
@@ -270,11 +271,12 @@ helm install "$RELEASE" "./$CHART_DIR" \
   -f "${CI_DIR}/test-secretref-registry.yaml" \
   -n "$NAMESPACE" --wait=false
 
-# Verify chart did NOT create docker-login (imagePullSecret.name is set — user manages their own)
+# Verify the hook did NOT create docker-login (user provides own)
+sleep 10
 if ! check_secret_exists "entitle-agent-docker-login"; then
-  pass "Test 3: no docker-login created (user provides own registry secret)"
+  pass "Test 3: no hook-created docker-login (user provides own registry secret)"
 else
-  fail "Test 3: docker-login exists unexpectedly"
+  fail "Test 3: hook-created docker-login exists unexpectedly"
 fi
 
 # Verify pod comes up

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -115,46 +115,21 @@ Fullname with image tag
   {{- end -}}
 {{- end -}}
 
-{{/* Resolves the raw token blob (base64-encoded JSON) from either:
-     1. agent.token value (simple install path)
-     2. lookup of agent.secretRef.name secret (GitOps path — reads the pre-existing secret at render time)
-     The lookup only works during helm install/upgrade (not helm template). */}}
-{{- define "entitle-agent.resolveTokenBlob" -}}
-  {{- $token := include "entitle-agent.getToken" . -}}
-  {{- if $token -}}
-    {{- $token -}}
-  {{- else if .Values.agent.secretRef.name -}}
-    {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.agent.secretRef.name -}}
-    {{- if $secret -}}
-      {{- $key := include "entitle-agent.agentSecretKey" . -}}
-      {{- if hasKey $secret.data $key -}}
-        {{- $tokenJson := index $secret.data $key | b64dec -}}
-        {{- if hasPrefix "{" $tokenJson -}}
-          {{- $configJson := $tokenJson | fromJson -}}
-          {{- if hasKey $configJson "BASE64_CONFIGURATION" -}}
-            {{- $configJson.BASE64_CONFIGURATION -}}
-          {{- end -}}
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-
-{{/* Resolves datadogApiKey: explicit value > extract from token > lookup from secretRef */}}
+{{/* Resolves datadogApiKey: --set datadog.datadog.apiKey takes priority, otherwise extract from token */}}
 {{- define "entitle-agent.datadogApiKey" -}}
   {{- if and .Values.datadog.datadog.apiKey (ne .Values.datadog.datadog.apiKey "") -}}
     {{- .Values.datadog.datadog.apiKey -}}
   {{- else -}}
-    {{- include "entitle-agent.extractTokenField" (dict "token" (include "entitle-agent.resolveTokenBlob" .) "field" "datadogApiKey") -}}
+    {{- include "entitle-agent.extractTokenField" (dict "token" (include "entitle-agent.getToken" .) "field" "datadogApiKey") -}}
   {{- end -}}
 {{- end -}}
 
-{{/* Resolves imageCredentials: explicit value > extract from token > lookup from secretRef */}}
+{{/* Resolves imageCredentials: --set imageCredentials takes priority, otherwise extract from token */}}
 {{- define "entitle-agent.imageCredentials" -}}
   {{- if and .Values.imageCredentials (ne .Values.imageCredentials "") (ne .Values.imageCredentials "MISSING_CUSTOMER_DATA") -}}
     {{- .Values.imageCredentials -}}
   {{- else -}}
-    {{- include "entitle-agent.extractTokenField" (dict "token" (include "entitle-agent.resolveTokenBlob" .) "field" "imageCredentials") -}}
+    {{- include "entitle-agent.extractTokenField" (dict "token" (include "entitle-agent.getToken" .) "field" "imageCredentials") -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/entitle-agent/templates/docker-login.yaml
+++ b/charts/entitle-agent/templates/docker-login.yaml
@@ -1,12 +1,12 @@
 {{/*
 Docker registry login secret.
-Skipped when imagePullSecret.name is set (user manages their own).
-Otherwise resolves imageCredentials from:
-  1. imageCredentials value (explicit --set)
-  2. agent.token blob (auto-extracted)
-  3. agent.secretRef secret (via Helm lookup at deploy time)
+Priority chain for image pull credentials:
+  1. imagePullSecret.existingSecret — reference a pre-existing Secret (for GitOps/ESO)
+  2. imageCredentials (explicit) — override value passed via --set
+  3. Auto-extracted from agent.token blob — the token contains imageCredentials inside it
+If none of the above are set, no docker-login Secret is created and imagePullSecrets
+is omitted from the Deployment (useful when nodes already have registry access).
 */}}
-{{- if not .Values.imagePullSecret.name -}}
 {{- $imageCreds := include "entitle-agent.imageCredentials" . -}}
 {{- if $imageCreds }}
 apiVersion: v1
@@ -18,5 +18,4 @@ metadata:
 data:
   .dockerconfigjson: {{ $imageCreds | quote }}
 type: kubernetes.io/dockerconfigjson
-{{- end }}
 {{- end }}

--- a/charts/entitle-agent/templates/extract-pull-secret-hook.yaml
+++ b/charts/entitle-agent/templates/extract-pull-secret-hook.yaml
@@ -1,0 +1,169 @@
+{{/*
+Pre-install/upgrade hook: extracts imageCredentials from the agent token secret
+and creates a docker-login imagePullSecret. This enables single-value installs
+with agent.secretRef.name — no need to separately provide imagePullSecret.name.
+
+Only runs when:
+  - agent.secretRef.name is set (secretRef path)
+  - imagePullSecret.name is NOT set (user didn't provide their own)
+  - agent.token is empty (not the token path — that creates docker-login directly)
+  - imageCredentials is empty (no explicit override)
+*/}}
+{{- $hasToken := and .Values.agent.token (ne .Values.agent.token "MISSING_CUSTOMER_DATA") -}}
+{{- if and .Values.agent.secretRef.name (not $hasToken) }}
+---
+# Hook ServiceAccount — needed for pre-install when the main SA doesn't exist yet
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "entitle-agent.fullname" . }}-hook
+  labels:
+    {{- include "entitle-agent.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "entitle-agent.fullname" . }}-hook
+  labels:
+    {{- include "entitle-agent.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "entitle-agent.fullname" . }}-hook
+  labels:
+    {{- include "entitle-agent.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "entitle-agent.fullname" . }}-hook
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "entitle-agent.fullname" . }}-hook
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "entitle-agent.fullname" . }}-extract-pull-secret
+  labels:
+    {{- include "entitle-agent.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "entitle-agent.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "entitle-agent.fullname" . }}-hook
+      restartPolicy: Never
+      containers:
+      - name: extract
+        image: bitnami/kubectl:latest
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          set -e
+
+          NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          SECRET_NAME="{{ include "entitle-agent.fullname" . }}-docker-login"
+
+          echo "Reading token from secret {{ .Values.agent.secretRef.name }}"
+
+          # Read the token JSON from the mounted secret file
+          TOKEN_JSON=$(cat "/secret/{{ include "entitle-agent.agentSecretKey" . }}")
+
+          # Extract BASE64_CONFIGURATION value from the JSON
+          B64_CONFIG=$(echo "$TOKEN_JSON" | sed 's/.*BASE64_CONFIGURATION":"\([^"]*\).*/\1/')
+
+          if [ -z "$B64_CONFIG" ] || [ "$B64_CONFIG" = "$TOKEN_JSON" ]; then
+            echo "ERROR: Could not extract BASE64_CONFIGURATION from secret"
+            exit 1
+          fi
+
+          # Decode to get the full token JSON
+          FULL_TOKEN=$(echo "$B64_CONFIG" | base64 -d)
+
+          # --- Docker login secret ---
+          {{- $hasImageCreds := and .Values.imageCredentials (ne .Values.imageCredentials "MISSING_CUSTOMER_DATA") }}
+          {{- if not (or .Values.imagePullSecret.name $hasImageCreds) }}
+          IMAGE_CREDS=$(echo "$FULL_TOKEN" | sed 's/.*"imageCredentials":"\([^"]*\)".*/\1/')
+
+          if [ -n "$IMAGE_CREDS" ] && [ "$IMAGE_CREDS" != "$FULL_TOKEN" ]; then
+            echo "Extracted imageCredentials, creating docker-login secret: ${SECRET_NAME}"
+            cat <<EOF | kubectl apply -f -
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ${SECRET_NAME}
+            namespace: ${NAMESPACE}
+            labels:
+              app.kubernetes.io/managed-by: Helm
+            annotations:
+              meta.helm.sh/release-name: {{ .Release.Name }}
+              meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+          type: kubernetes.io/dockerconfigjson
+          data:
+            .dockerconfigjson: ${IMAGE_CREDS}
+          EOF
+          else
+            echo "WARNING: No imageCredentials found in token."
+          fi
+          {{- else }}
+          echo "Skipping docker-login (imagePullSecret.name or imageCredentials provided)"
+          {{- end }}
+
+          # --- Datadog API key secret ---
+          DD_SECRET_NAME="{{ include "entitle-agent.fullname" . }}-datadog-secret"
+          DD_API_KEY=$(echo "$FULL_TOKEN" | sed 's/.*"datadogApiKey":"\([^"]*\)".*/\1/')
+
+          if [ -n "$DD_API_KEY" ] && [ "$DD_API_KEY" != "$FULL_TOKEN" ]; then
+            echo "Extracted datadogApiKey, creating Datadog secret: ${DD_SECRET_NAME}"
+            cat <<EOF | kubectl apply -f -
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ${DD_SECRET_NAME}
+            namespace: ${NAMESPACE}
+            labels:
+              app.kubernetes.io/managed-by: Helm
+            annotations:
+              meta.helm.sh/release-name: {{ .Release.Name }}
+              meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+          stringData:
+            api-key: "${DD_API_KEY}"
+            DD_API_KEY: "${DD_API_KEY}"
+          EOF
+          else
+            echo "WARNING: No datadogApiKey found in token. Datadog API key must be set via datadog.datadog.apiKey."
+          fi
+
+          echo "Done."
+        volumeMounts:
+        - name: token-secret
+          mountPath: /secret
+          readOnly: true
+      volumes:
+      - name: token-secret
+        secret:
+          secretName: {{ .Values.agent.secretRef.name }}
+{{- end }}


### PR DESCRIPTION
## Summary
- Reverts the v2.1.0 changes that replaced the hook-based secret extraction with Helm `lookup` (DOPS-646)
- Restores the pre-install/upgrade hook Job for extracting `imageCredentials` and `datadogApiKey` from the agent token secret
- Bumps chart version to 2.1.1 to satisfy the lint version-increment check

## What changed
- `extract-pull-secret-hook.yaml` restored
- `_helpers.tpl` reverted (removes `resolveTokenBlob` helper, restores original `datadogApiKey`/`imageCredentials` helpers)
- `docker-login.yaml` reverted
- `README.md` reverted
- `integration-test.sh` reverted
- Chart version: 2.1.0 → 2.1.1

## Test plan
- [ ] `helm lint` passes
- [ ] CI checks pass
- [ ] Verify hook-based flow works on dev cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)