### PR TITLE
docs(entitle-agent): drop unneeded datadog repo step, fix stale changelog note

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -4,14 +4,14 @@ description: An Entitle agent Helm chart for Kubernetes
 type: application
 icon: https://app.entitle.io/favicon.ico
 
-# Breaking change in v2.0.0: defaults changed (MISSING_CUSTOMER_DATA removed,
-# kmsType defaults to kubernetes_secret_manager, token/imageCredentials no longer required).
+# Breaking change in v2.0.0: defaults changed (kmsType defaults to
+# kubernetes_secret_manager, token/imageCredentials no longer required).
 # GCP platform field renamed from platform.gke to platform.gcp.
 # See DOPS-434 for full changelog.
 # v2.5.0 (ICH-4992): fail helm install/upgrade with a clear message when imageCredentials
 # or datadogApiKey cannot be resolved from agent.token or explicit values, instead of
 # deploying into a broken state.
-version: 2.5.0
+version: 2.5.1
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/README.md
+++ b/charts/entitle-agent/README.md
@@ -109,7 +109,6 @@ helm upgrade --install entitle-agent entitle/entitle-agent \
 ## Pre-Install
 
 ```shell
-helm repo add datadog https://helm.datadoghq.com
 helm repo add entitle https://anycred.github.io/entitle-charts/
 ```
 


### PR DESCRIPTION
## What

Fixes two pieces of misleading information in the `entitle-agent` chart docs, surfaced while answering a question about what outbound connections a customer needs to **pull** the chart.

### 1. README — remove the `helm repo add datadog` prerequisite
The Pre-Install section told customers to add the Datadog Helm repo. That repo is **not needed to pull or install the published chart**: the `datadog` subchart (with its `datadog-crds` / `kube-state-metrics` deps) is vendored into the published `entitle-agent-*.tgz`. A customer only needs the `entitle` repo.

> CI's `integration-test` job still runs `helm repo add datadog … && helm dependency build` because it rebuilds dependencies from source — that path is unaffected by this change.

### 2. Chart.yaml — fix stale changelog comment
The header comment claimed the v2.0.0 breaking change *"MISSING_CUSTOMER_DATA removed"*. It was **not** removed — it's still an active sentinel: templates guard on `ne .Values.agent.token "MISSING_CUSTOMER_DATA"` (and `imageCredentials`), and it remains the default in `values.yaml`. Only the comment is corrected; the actual default is untouched.

### 3. Chart.yaml — version bump `2.5.0 → 2.5.1`
`ct lint` enforces a version increment for any chart change, and `2.5.0` is already released/tagged.

## Verification
- `helm lint charts/entitle-agent` → `1 chart(s) linted, 0 chart(s) failed`
- Docs-only change; no template/values behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)