### PR TITLE
feat(entitle-agent): pull the agent image through the registry proxy

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -12,9 +12,12 @@ icon: https://app.entitle.io/favicon.ico
 # or datadogApiKey cannot be resolved from agent.token or explicit values, instead of
 # deploying into a broken state.
 # v2.6.0: optionally pull the monitoring-agent image through the on-prem registry proxy.
-# v2.7.0 (DOPS-678): also pull the agent image through the proxy (routing v1+), keyed
+# v2.7.0: extract-pull-secret hook parses the token with jq (handles multi-line
+# token JSON) instead of a line-oriented sed, fixing 401 ImagePullBackOff on the
+# agent.secretRef install path.
+# v2.8.0 (DOPS-678): also pull the agent image through the proxy (routing v1+), keyed
 # to the proxy host; the agent and monitoring-agent images share one proxy URL.
-version: 2.7.0
+version: 2.8.0
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -12,7 +12,9 @@ icon: https://app.entitle.io/favicon.ico
 # or datadogApiKey cannot be resolved from agent.token or explicit values, instead of
 # deploying into a broken state.
 # v2.6.0: optionally pull the monitoring-agent image through the on-prem registry proxy.
-version: 2.6.0
+# v2.7.0 (DOPS-678): also pull the agent image through the proxy (routing v1+), keyed
+# to the proxy host; the agent and monitoring-agent images share one proxy URL.
+version: 2.7.0
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -231,6 +231,49 @@ Docs: https://docs.beyondtrust.com/entitle/docs/entitle-agent
   {{- end -}}
 {{- end -}}
 
+{{/* Agent image repository, selected by the token's "routing" field (mirrors
+     entitle-agent.datadogRegistry):
+       v0 / field absent  -> pull direct from the configured registry (agent.image.repository)
+       v1 (or higher)     -> pull through the proxy: swap the registry host for the proxy
+                             host (agent.{platform}.entitle.io), keeping the repo path. The
+                             proxy's default/catch-all route forwards it to the real upstream
+                             (ghcr.io), so the image ref never embeds the upstream host. */}}
+{{- define "entitle-agent.agentImageRepository" -}}
+  {{- $routing := include "entitle-agent.extractedRouting" . | trim -}}
+  {{- $proxyUrl := include "entitle-agent.proxyUrl" . -}}
+  {{- $repository := .Values.agent.image.repository -}}
+  {{- if and $routing (ne $routing "v0") $proxyUrl -}}
+    {{- $host := $proxyUrl | trimPrefix "http://" | trimSuffix ":8080" -}}
+    {{- $path := regexReplaceAll "^[^/]+/" $repository "" -}}
+    {{- printf "%s/%s" $host $path -}}
+  {{- else -}}
+    {{- $repository -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* dockerconfigjson for the agent image pull secret. The agent image is private
+     (ghcr), so containerd needs registry credentials keyed to the host in the image
+     ref. When pulling through the proxy (routing v1+) that host is the proxy host, so
+     re-key the auths entries from the upstream registry host to the proxy host (the
+     username/password are unchanged — the proxy forwards the basic-auth /token call to
+     the real upstream). Otherwise pass imageCredentials through unchanged. */}}
+{{- define "entitle-agent.dockerConfigJson" -}}
+  {{- $imageCreds := include "entitle-agent.imageCredentials" . -}}
+  {{- $routing := include "entitle-agent.extractedRouting" . | trim -}}
+  {{- $proxyUrl := include "entitle-agent.proxyUrl" . -}}
+  {{- if and $imageCreds $routing (ne $routing "v0") $proxyUrl -}}
+    {{- $host := $proxyUrl | trimPrefix "http://" | trimSuffix ":8080" -}}
+    {{- $decoded := $imageCreds | b64dec | fromJson -}}
+    {{- $newAuths := dict -}}
+    {{- range $k, $v := $decoded.auths -}}
+      {{- $_ := set $newAuths $host $v -}}
+    {{- end -}}
+    {{- dict "auths" $newAuths | toJson | b64enc -}}
+  {{- else -}}
+    {{- $imageCreds -}}
+  {{- end -}}
+{{- end -}}
+
 {{/* ============================================================
      Secret reference helpers
      ============================================================ */}}

--- a/charts/entitle-agent/templates/deployment.yaml
+++ b/charts/entitle-agent/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
       # Healthcheck validators must exit 0 before the main agent container starts.
       # This guarantees the agent never consumes Kafka messages in an invalid state.
       - name: {{ include "entitle-agent.fullname" . }}-healthcheck
-        image: {{ .Values.agent.image.repository }}:{{ include "entitle-agent.resolvedImageTag" . }}
+        image: {{ include "entitle-agent.agentImageRepository" . }}:{{ include "entitle-agent.resolvedImageTag" . }}
         imagePullPolicy: Always
         command:
           - python
@@ -102,7 +102,7 @@ spec:
         {{- end }}
       containers:
       - name: {{ include "entitle-agent.fullname" . }}
-        image: {{ .Values.agent.image.repository }}:{{ include "entitle-agent.resolvedImageTag" . }}
+        image: {{ include "entitle-agent.agentImageRepository" . }}:{{ include "entitle-agent.resolvedImageTag" . }}
         imagePullPolicy: Always
         env:
         {{- include "entitle-agent.agentEnv" . | nindent 8 }}

--- a/charts/entitle-agent/templates/docker-login.yaml
+++ b/charts/entitle-agent/templates/docker-login.yaml
@@ -9,6 +9,7 @@ Docker registry login secret.
 {{- $hasToken := and .Values.agent.token (ne .Values.agent.token "MISSING_CUSTOMER_DATA") }}
 {{- if not .Values.imagePullSecret.name -}}
 {{- $imageCreds := include "entitle-agent.imageCredentials" . -}}
+{{- $dockerConfig := include "entitle-agent.dockerConfigJson" . -}}
 {{- if or $imageCreds .Values.agent.secretRef.name }}
 apiVersion: v1
 kind: Secret
@@ -25,7 +26,7 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   {{- if $imageCreds }}
-  .dockerconfigjson: {{ $imageCreds | quote }}
+  .dockerconfigjson: {{ $dockerConfig | quote }}
   {{- else }}
   .dockerconfigjson: eyJhdXRocyI6e319
   {{- end }}

--- a/charts/entitle-agent/templates/hook-extract-job.yaml
+++ b/charts/entitle-agent/templates/hook-extract-job.yaml
@@ -63,22 +63,20 @@ spec:
           # routing v1+ pulls the agent image through the proxy host, so the pull
           # secret must be keyed to that host instead of the upstream registry
           # (mirrors entitle-agent.dockerConfigJson for the render-time token path).
-          ROUTING=$(echo "$FULL_TOKEN" | sed 's/.*"routing":"\([^"]*\)".*/\1/')
-          PLATFORM=$(echo "$FULL_TOKEN" | sed 's/.*"platform":"\([^"]*\)".*/\1/')
-          if [ -n "$IMAGE_CREDS" ] && [ "$IMAGE_CREDS" != "$FULL_TOKEN" ] \
-             && [ -n "$ROUTING" ] && [ "$ROUTING" != "v0" ] && [ "$ROUTING" != "$FULL_TOKEN" ] \
-             && [ -n "$PLATFORM" ] && [ "$PLATFORM" != "$FULL_TOKEN" ]; then
+          ROUTING=$(echo "$FULL_TOKEN" | jq -r '.routing // empty')
+          PLATFORM=$(echo "$FULL_TOKEN" | jq -r '.platform // empty')
+          if [ -n "$IMAGE_CREDS" ] && [ -n "$ROUTING" ] && [ "$ROUTING" != "v0" ] && [ -n "$PLATFORM" ]; then
             case "$PLATFORM" in
               dev-*) PROXY_HOST="agent-${PLATFORM#dev-}.dev.entitle.io" ;;
               *)     PROXY_HOST="agent.${PLATFORM}.entitle.io" ;;
             esac
             echo "routing=$ROUTING: re-keying pull secret to proxy host $PROXY_HOST"
             IMAGE_CREDS=$(echo "$IMAGE_CREDS" | base64 -d \
-              | sed -E "s#(\"auths\"[[:space:]]*:[[:space:]]*\{[[:space:]]*)\"[^\"]+\"#\1\"${PROXY_HOST}\"#" \
+              | jq -c --arg h "$PROXY_HOST" '{auths: (.auths | to_entries | map(.key = $h) | from_entries)}' \
               | base64 -w0)
           fi
 
-          if [ -n "$IMAGE_CREDS" ] && [ "$IMAGE_CREDS" != "$FULL_TOKEN" ]; then
+          if [ -n "$IMAGE_CREDS" ]; then
             echo "Patching docker-login secret with extracted imageCredentials"
             kubectl patch secret "{{ include "entitle-agent.fullname" . }}-docker-login" \
               -n "$NAMESPACE" \

--- a/charts/entitle-agent/templates/hook-extract-job.yaml
+++ b/charts/entitle-agent/templates/hook-extract-job.yaml
@@ -58,6 +58,24 @@ spec:
           {{- if not (or .Values.imagePullSecret.name $hasImageCreds) }}
           IMAGE_CREDS=$(echo "$FULL_TOKEN" | sed 's/.*"imageCredentials":"\([^"]*\)".*/\1/')
 
+          # routing v1+ pulls the agent image through the proxy host, so the pull
+          # secret must be keyed to that host instead of the upstream registry
+          # (mirrors entitle-agent.dockerConfigJson for the render-time token path).
+          ROUTING=$(echo "$FULL_TOKEN" | sed 's/.*"routing":"\([^"]*\)".*/\1/')
+          PLATFORM=$(echo "$FULL_TOKEN" | sed 's/.*"platform":"\([^"]*\)".*/\1/')
+          if [ -n "$IMAGE_CREDS" ] && [ "$IMAGE_CREDS" != "$FULL_TOKEN" ] \
+             && [ -n "$ROUTING" ] && [ "$ROUTING" != "v0" ] && [ "$ROUTING" != "$FULL_TOKEN" ] \
+             && [ -n "$PLATFORM" ] && [ "$PLATFORM" != "$FULL_TOKEN" ]; then
+            case "$PLATFORM" in
+              dev-*) PROXY_HOST="agent-${PLATFORM#dev-}.dev.entitle.io" ;;
+              *)     PROXY_HOST="agent.${PLATFORM}.entitle.io" ;;
+            esac
+            echo "routing=$ROUTING: re-keying pull secret to proxy host $PROXY_HOST"
+            IMAGE_CREDS=$(echo "$IMAGE_CREDS" | base64 -d \
+              | sed -E "s#(\"auths\"[[:space:]]*:[[:space:]]*\{[[:space:]]*)\"[^\"]+\"#\1\"${PROXY_HOST}\"#" \
+              | base64 -w0)
+          fi
+
           if [ -n "$IMAGE_CREDS" ] && [ "$IMAGE_CREDS" != "$FULL_TOKEN" ]; then
             echo "Patching docker-login secret with extracted imageCredentials"
             kubectl patch secret "{{ include "entitle-agent.fullname" . }}-docker-login" \


### PR DESCRIPTION
## What

Completes DOPS-678: when the token's **routing is v1+**, the agent image is pulled through the on-prem proxy host (`agent.<platform>.entitle.io/anycred/entitle-agent`) instead of direct from ghcr — mirroring the existing monitoring-agent behavior, so **both images share one proxy URL**. routing `v0`/absent stays direct from ghcr/gcr (unchanged).

## How

- **`agentImageRepository` helper** — swaps the registry host for the proxy host, keeping the repo path. The proxy's default/catch-all route forwards it to the real upstream (ghcr), so the image ref never embeds the upstream host. Modeled on `datadogRegistry`.
- **`dockerConfigJson` helper** — the agent image is private (ghcr), so containerd needs credentials keyed to the host in the image ref. When pulling through the proxy this is the proxy host, so the helper re-keys the pull-secret `auths` entries from the upstream host to the proxy host (username/password unchanged — the proxy forwards the basic-auth `/token` call to the real upstream).
- **secretRef hook job** — does the same re-keying at runtime (extracts `routing`/`platform` from the token and rewrites the pull secret's `auths` host).
- Chart bumped to **2.7.0**.

## Validation

`helm lint` clean. Render checks:

| routing | agent image | datadog image | pull secret keyed to |
|---|---|---|---|
| **v1** | `agent.qa.entitle.io/anycred/entitle-agent-qa` | `agent.qa.entitle.io/monitoring-agent/agent` | `agent.qa.entitle.io` |
| **v0** | `ghcr.io/anycred/entitle-agent-qa` | `gcr.io/datadoghq/agent` | `ghcr.io` |

Pairs with the gitops PR (proxy-side: path-routed multi-upstream registry listener).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
