### PR TITLE
fix(entitle-agent): parse token with jq in extract-pull-secret hook

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -12,7 +12,10 @@ icon: https://app.entitle.io/favicon.ico
 # or datadogApiKey cannot be resolved from agent.token or explicit values, instead of
 # deploying into a broken state.
 # v2.6.0: optionally pull the monitoring-agent image through the on-prem registry proxy.
-version: 2.6.0
+# v2.7.0: extract-pull-secret hook parses the token with jq (handles multi-line
+# token JSON) instead of a line-oriented sed, fixing 401 ImagePullBackOff on the
+# agent.secretRef install path.
+version: 2.7.0
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/hook-extract-job.yaml
+++ b/charts/entitle-agent/templates/hook-extract-job.yaml
@@ -42,10 +42,12 @@ spec:
           # Read the token JSON from the mounted secret file
           TOKEN_JSON=$(cat "/secret/{{ include "entitle-agent.agentSecretKey" . }}")
 
-          # Unwrap BASE64_CONFIGURATION to get the raw token blob
-          B64_CONFIG=$(echo "$TOKEN_JSON" | sed 's/.*BASE64_CONFIGURATION":"\([^"]*\).*/\1/')
+          # Unwrap BASE64_CONFIGURATION to get the raw token blob.
+          # Use jq (present in bitnami/kubectl) so parsing is robust to JSON
+          # whitespace, newlines and key ordering — a plain sed regex is not.
+          B64_CONFIG=$(echo "$TOKEN_JSON" | jq -r '.BASE64_CONFIGURATION // empty')
 
-          if [ -z "$B64_CONFIG" ] || [ "$B64_CONFIG" = "$TOKEN_JSON" ]; then
+          if [ -z "$B64_CONFIG" ]; then
             echo "ERROR: Could not extract BASE64_CONFIGURATION from secret"
             exit 1
           fi
@@ -56,9 +58,9 @@ spec:
           # --- Patch docker-login secret ---
           {{- $hasImageCreds := and .Values.imageCredentials (ne .Values.imageCredentials "MISSING_CUSTOMER_DATA") }}
           {{- if not (or .Values.imagePullSecret.name $hasImageCreds) }}
-          IMAGE_CREDS=$(echo "$FULL_TOKEN" | sed 's/.*"imageCredentials":"\([^"]*\)".*/\1/')
+          IMAGE_CREDS=$(echo "$FULL_TOKEN" | jq -r '.imageCredentials // empty')
 
-          if [ -n "$IMAGE_CREDS" ] && [ "$IMAGE_CREDS" != "$FULL_TOKEN" ]; then
+          if [ -n "$IMAGE_CREDS" ]; then
             echo "Patching docker-login secret with extracted imageCredentials"
             kubectl patch secret "{{ include "entitle-agent.fullname" . }}-docker-login" \
               -n "$NAMESPACE" \
@@ -72,9 +74,9 @@ spec:
           {{- end }}
 
           # --- Patch datadog secret ---
-          DD_API_KEY=$(echo "$FULL_TOKEN" | sed 's/.*"datadogApiKey":"\([^"]*\)".*/\1/')
+          DD_API_KEY=$(echo "$FULL_TOKEN" | jq -r '.datadogApiKey // empty')
 
-          if [ -n "$DD_API_KEY" ] && [ "$DD_API_KEY" != "$FULL_TOKEN" ]; then
+          if [ -n "$DD_API_KEY" ]; then
             echo "Patching datadog secret with extracted datadogApiKey"
             kubectl patch secret "{{ include "entitle-agent.fullname" . }}-datadog-secret" \
               -n "$NAMESPACE" \


### PR DESCRIPTION
## Problem

The `extract-pull-secret` hook reads the agent token from the referenced Secret
(the `agent.secretRef` path) and patches the placeholder `docker-login` /
datadog secrets with credentials extracted from the token blob. It extracted
them with a line-oriented `sed` regex:

```
IMAGE_CREDS=$(echo "$FULL_TOKEN" | sed 's/.*"imageCredentials":"\([^"]*\)".*/\1/')
```

When the decoded token blob is **pretty-printed (multi-line) JSON**, this regex
matches nothing and `sed` returns the **entire blob** unchanged. The hook then
patches `docker-login` with that garbage, so the image pull presents invalid
credentials, falls back to anonymous, and fails with **401 / ImagePullBackOff**.

Reproduced in CI: a multi-line ("v1") token fails on the `secretRef` install
path, while a compact ("v0") token works — and the same multi-line token pulls
fine through every other path (template-side extraction, or a user-provided
image-pull secret), proving the credentials are valid and the hook's `sed` is
the defect.

## Fix

`bitnami/kubectl` (the hook image) ships `jq`, so parse the token with `jq`
instead of `sed`. This is robust to whitespace, newlines and key ordering, and
matches the chart's template-side `extractTokenField` helper. Applied to all
three extractions in the hook (`BASE64_CONFIGURATION`, `imageCredentials`,
`datadogApiKey`).

## Validation

- Simulated the old vs new extraction inside the real `bitnami/kubectl` image:
  `jq` extracts correctly for both compact and pretty-printed JSON; `sed`
  returns the whole blob for pretty-printed (the bug).
- `helm lint` + `helm template` pass.
- End-to-end: the `entitle-charts-tests` suite is being re-run against this
  branch to confirm the `secretRef` + multi-line-token case now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
