### PR TITLE
ci: gate chart PRs on entitle-charts-tests suite

### DIFF
--- a/.github/workflows/agent-tests.yml
+++ b/.github/workflows/agent-tests.yml
@@ -6,8 +6,9 @@ name: agent-tests
 # immediately — so this can be a required status check without blocking
 # unrelated PRs.
 #
-# Requires repo secret AGENT_TESTS_PAT: a fine-grained PAT scoped to
-# anycred/entitle-charts-tests with "Actions: read and write".
+# Auth: a GitHub App (secrets AGENT_TESTS_APP_ID + AGENT_TESTS_APP_PRIVATE_KEY)
+# installed on anycred/entitle-charts-tests with "Actions: read and write".
+# A short-lived installation token is minted per run — no standing credential.
 on:
   pull_request:
     branches: [master]
@@ -41,19 +42,34 @@ jobs:
             echo "No entitle-agent chart changes — skipping agent tests."
           fi
 
+      - name: Verify App credentials are available
+        if: steps.detect.outputs.run == 'true'
+        env:
+          APP_ID: ${{ secrets.AGENT_TESTS_APP_ID }}
+        run: |
+          if [ -z "${APP_ID:-}" ]; then
+            echo "::error::GitHub App credentials not available (fork PR or App not configured); cannot run the private suite."
+            exit 1
+          fi
+
+      - name: Mint token for entitle-charts-tests
+        id: app-token
+        if: steps.detect.outputs.run == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AGENT_TESTS_APP_ID }}
+          private-key: ${{ secrets.AGENT_TESTS_APP_PRIVATE_KEY }}
+          owner: anycred
+          repositories: entitle-charts-tests
+
       - name: Dispatch and wait for entitle-charts-tests
         if: steps.detect.outputs.run == 'true'
         env:
-          GH_TOKEN: ${{ secrets.AGENT_TESTS_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TESTS_REPO: anycred/entitle-charts-tests
           CHART_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::AGENT_TESTS_PAT is not available (fork PR or missing secret); cannot run the private suite."
-            exit 1
-          fi
-
           since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           echo "Dispatching orchestrator (chart_ref=$CHART_SHA)"
           gh workflow run orchestrator.yaml --repo "$TESTS_REPO" --ref master -f chart_ref="$CHART_SHA"

--- a/.github/workflows/agent-tests.yml
+++ b/.github/workflows/agent-tests.yml
@@ -6,9 +6,8 @@ name: agent-tests
 # immediately — so this can be a required status check without blocking
 # unrelated PRs.
 #
-# Auth: a GitHub App (secrets AGENT_TESTS_APP_ID + AGENT_TESTS_APP_PRIVATE_KEY)
-# installed on anycred/entitle-charts-tests with "Actions: read and write".
-# A short-lived installation token is minted per run — no standing credential.
+# Requires repo secret AGENT_TESTS_PAT: a fine-grained PAT scoped to
+# anycred/entitle-charts-tests with "Actions: read and write".
 on:
   pull_request:
     branches: [master]
@@ -42,34 +41,19 @@ jobs:
             echo "No entitle-agent chart changes — skipping agent tests."
           fi
 
-      - name: Verify App credentials are available
-        if: steps.detect.outputs.run == 'true'
-        env:
-          APP_ID: ${{ secrets.AGENT_TESTS_APP_ID }}
-        run: |
-          if [ -z "${APP_ID:-}" ]; then
-            echo "::error::GitHub App credentials not available (fork PR or App not configured); cannot run the private suite."
-            exit 1
-          fi
-
-      - name: Mint token for entitle-charts-tests
-        id: app-token
-        if: steps.detect.outputs.run == 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.AGENT_TESTS_APP_ID }}
-          private-key: ${{ secrets.AGENT_TESTS_APP_PRIVATE_KEY }}
-          owner: anycred
-          repositories: entitle-charts-tests
-
       - name: Dispatch and wait for entitle-charts-tests
         if: steps.detect.outputs.run == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.AGENT_TESTS_PAT }}
           TESTS_REPO: anycred/entitle-charts-tests
           CHART_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::AGENT_TESTS_PAT is not available (fork PR or missing secret); cannot run the private suite."
+            exit 1
+          fi
+
           since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           echo "Dispatching orchestrator (chart_ref=$CHART_SHA)"
           gh workflow run orchestrator.yaml --repo "$TESTS_REPO" --ref master -f chart_ref="$CHART_SHA"

--- a/.github/workflows/agent-tests.yml
+++ b/.github/workflows/agent-tests.yml
@@ -1,0 +1,82 @@
+name: agent-tests
+
+# Gates chart PRs on the private end-to-end suite in anycred/entitle-charts-tests.
+# When chart files change, dispatches that repo's orchestrator against this PR's
+# head SHA, waits, and mirrors the result. When no chart files change, passes
+# immediately — so this can be a required status check without blocking
+# unrelated PRs.
+#
+# Requires repo secret AGENT_TESTS_PAT: a fine-grained PAT scoped to
+# anycred/entitle-charts-tests with "Actions: read and write".
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: agent-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  agent-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect chart changes
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          files=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
+          if echo "$files" | grep -qE '^charts/entitle-agent/'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Chart files changed — will run the agent test suite."
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No entitle-agent chart changes — skipping agent tests."
+          fi
+
+      - name: Dispatch and wait for entitle-charts-tests
+        if: steps.detect.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_TESTS_PAT }}
+          TESTS_REPO: anycred/entitle-charts-tests
+          CHART_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::AGENT_TESTS_PAT is not available (fork PR or missing secret); cannot run the private suite."
+            exit 1
+          fi
+
+          since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          echo "Dispatching orchestrator (chart_ref=$CHART_SHA)"
+          gh workflow run orchestrator.yaml --repo "$TESTS_REPO" --ref master -f chart_ref="$CHART_SHA"
+
+          echo "Locating the dispatched run..."
+          run_id=""
+          for _ in $(seq 1 20); do
+            sleep 6
+            run_id=$(gh run list --repo "$TESTS_REPO" --workflow orchestrator.yaml \
+              --event workflow_dispatch --limit 30 --json databaseId,name,createdAt \
+              --jq "[.[] | select(.createdAt >= \"$since\") | select(.name | contains(\"$CHART_SHA\"))] | sort_by(.createdAt) | last | .databaseId // empty")
+            [ -n "$run_id" ] && break
+          done
+          if [ -z "$run_id" ]; then
+            echo "::error::Could not find the dispatched test run."
+            exit 1
+          fi
+
+          run_url="https://github.com/$TESTS_REPO/actions/runs/$run_id"
+          echo "Test run: $run_url"
+          echo "Waiting for it to finish..."
+          gh run watch "$run_id" --repo "$TESTS_REPO" --interval 20 >/dev/null 2>&1 || true
+
+          conclusion=$(gh run view "$run_id" --repo "$TESTS_REPO" --json conclusion --jq '.conclusion')
+          echo "::notice::agent-tests conclusion=$conclusion ($run_url)"
+          [ "$conclusion" = "success" ]


### PR DESCRIPTION
## What

Gates chart PRs on the private end-to-end suite in `anycred/entitle-charts-tests`.

`agent-tests.yml` runs on `pull_request`:
- **Chart files changed** (`charts/entitle-agent/**`) → dispatches the private
  `orchestrator.yaml` with `chart_ref` = this PR's head SHA, waits for it, and
  mirrors the conclusion (fails the check if the suite fails).
- **No chart files changed** → passes immediately, so it can be a required check
  without blocking unrelated PRs.

Test logs and the agent-token secrets stay in the private repo; this PR only
sees a pass/fail check.

## Required setup (admin)

1. **Fine-grained PAT** — resource owner `anycred`, repo access
   `anycred/entitle-charts-tests`, permission **Actions: Read and write**.
2. Add it as repo secret **`AGENT_TESTS_PAT`** on `anycred/entitle-charts`.
3. Merge the tests repo's suite to its `master` first (its `orchestrator.yaml`
   must exist on `master` for the dispatch to work).
4. **Branch protection** on `entitle-charts` `master`: require the **`agent-tests`**
   status check.

Until steps 1–3 are done, this workflow's own check will fail (expected) —
merge order matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
