### PR TITLE
fix(entitle-agent): respect custom image repositories with routing v1…

### DIFF
--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -217,20 +217,23 @@ Docs: https://docs.beyondtrust.com/entitle/docs/entitle-agent
 {{/* Full Datadog logs sidecar image reference including tag.
      Selected by the token's "routing" field:
        v0 / field absent  -> `datadog.image.repository`:`datadog.image.tag` as-is
-       v1 (or higher)     -> pull through the proxy: rewrite to
-                             `<proxyHost>/monitoring-agent/<basename>:<tag>` where
+       v1 (or higher)     -> pull through the proxy ONLY if using the default repository.
+                             Rewrite to `<proxyHost>/monitoring-agent/<basename>:<tag>` where
                              basename is the last "/"-separated segment of the
                              configured repository. Uses the same proxy host as
                              the agent image (agent.{platform}.entitle.io, from
                              entitle-agent.proxyUrl); the "monitoring-agent"
                              alias namespace is mapped back to the real upstream
-                             by the proxy. */}}
+                             by the proxy.
+                             If a custom (non-default) repository is explicitly configured,
+                             use it as-is to allow direct pulls from private mirrors. */}}
 {{- define "entitle-agent.datadogImage" -}}
   {{- $repository := .Values.datadog.image.repository -}}
   {{- $tag := .Values.datadog.image.tag | default "latest" -}}
   {{- $routing := include "entitle-agent.extractedRouting" . | trim -}}
   {{- $proxyUrl := include "entitle-agent.proxyUrl" . -}}
-  {{- if and $routing (ne $routing "v0") $proxyUrl -}}
+  {{- $isDefault := eq $repository "gcr.io/datadoghq/agent" -}}
+  {{- if and $routing (ne $routing "v0") $proxyUrl $isDefault -}}
     {{- $host := $proxyUrl | trimPrefix "http://" | trimSuffix ":8080" -}}
     {{- $basename := regexReplaceAll "^.*/" $repository "" -}}
     {{- printf "%s/monitoring-agent/%s:%s" $host $basename $tag -}}
@@ -242,15 +245,19 @@ Docs: https://docs.beyondtrust.com/entitle/docs/entitle-agent
 {{/* Agent image repository, selected by the token's "routing" field (mirrors
      entitle-agent.datadogRegistry):
        v0 / field absent  -> pull direct from the configured registry (agent.image.repository)
-       v1 (or higher)     -> pull through the proxy: swap the registry host for the proxy
-                             host (agent.{platform}.entitle.io), keeping the repo path. The
+       v1 (or higher)     -> pull through the proxy ONLY if using the default repository.
+                             Swap the registry host for the proxy host
+                             (agent.{platform}.entitle.io), keeping the repo path. The
                              proxy's default/catch-all route forwards it to the real upstream
-                             (ghcr.io), so the image ref never embeds the upstream host. */}}
+                             (ghcr.io), so the image ref never embeds the upstream host.
+                             If a custom (non-default) repository is explicitly configured,
+                             use it as-is to allow direct pulls from private mirrors. */}}
 {{- define "entitle-agent.agentImageRepository" -}}
   {{- $routing := include "entitle-agent.extractedRouting" . | trim -}}
   {{- $proxyUrl := include "entitle-agent.proxyUrl" . -}}
   {{- $repository := .Values.agent.image.repository -}}
-  {{- if and $routing (ne $routing "v0") $proxyUrl -}}
+  {{- $isDefault := eq $repository "ghcr.io/anycred/entitle-agent" -}}
+  {{- if and $routing (ne $routing "v0") $proxyUrl $isDefault -}}
     {{- $host := $proxyUrl | trimPrefix "http://" | trimSuffix ":8080" -}}
     {{- $path := regexReplaceAll "^[^/]+/" $repository "" -}}
     {{- printf "%s/%s" $host $path -}}

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -232,7 +232,7 @@ Docs: https://docs.beyondtrust.com/entitle/docs/entitle-agent
   {{- $tag := .Values.datadog.image.tag | default "latest" -}}
   {{- $routing := include "entitle-agent.extractedRouting" . | trim -}}
   {{- $proxyUrl := include "entitle-agent.proxyUrl" . -}}
-  {{- $isDefault := eq $repository "gcr.io/datadoghq/agent" -}}
+  {{- $isDefault := eq $repository .Values._defaults.datadogImageRepository -}}
   {{- if and $routing (ne $routing "v0") $proxyUrl $isDefault -}}
     {{- $host := $proxyUrl | trimPrefix "http://" | trimSuffix ":8080" -}}
     {{- $basename := regexReplaceAll "^.*/" $repository "" -}}
@@ -256,7 +256,7 @@ Docs: https://docs.beyondtrust.com/entitle/docs/entitle-agent
   {{- $routing := include "entitle-agent.extractedRouting" . | trim -}}
   {{- $proxyUrl := include "entitle-agent.proxyUrl" . -}}
   {{- $repository := .Values.agent.image.repository -}}
-  {{- $isDefault := eq $repository "ghcr.io/anycred/entitle-agent" -}}
+  {{- $isDefault := eq $repository .Values._defaults.agentImageRepository -}}
   {{- if and $routing (ne $routing "v0") $proxyUrl $isDefault -}}
     {{- $host := $proxyUrl | trimPrefix "http://" | trimSuffix ":8080" -}}
     {{- $path := regexReplaceAll "^[^/]+/" $repository "" -}}
@@ -271,12 +271,15 @@ Docs: https://docs.beyondtrust.com/entitle/docs/entitle-agent
      ref. When pulling through the proxy (routing v1+) that host is the proxy host, so
      re-key the auths entries from the upstream registry host to the proxy host (the
      username/password are unchanged — the proxy forwards the basic-auth /token call to
-     the real upstream). Otherwise pass imageCredentials through unchanged. */}}
+     the real upstream). Only rewrite if the agent repository is using the default.
+     If agent is custom, pass imageCredentials through unchanged to allow direct pulls
+     from private mirrors. */}}
 {{- define "entitle-agent.dockerConfigJson" -}}
   {{- $imageCreds := include "entitle-agent.imageCredentials" . -}}
   {{- $routing := include "entitle-agent.extractedRouting" . | trim -}}
   {{- $proxyUrl := include "entitle-agent.proxyUrl" . -}}
-  {{- if and $imageCreds $routing (ne $routing "v0") $proxyUrl -}}
+  {{- $agentIsDefault := eq .Values.agent.image.repository .Values._defaults.agentImageRepository -}}
+  {{- if and $imageCreds $routing (ne $routing "v0") $proxyUrl $agentIsDefault -}}
     {{- $host := $proxyUrl | trimPrefix "http://" | trimSuffix ":8080" -}}
     {{- $decoded := $imageCreds | b64dec | fromJson -}}
     {{- $newAuths := dict -}}

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -5,6 +5,13 @@
 # Chart repo: https://anycred.github.io/entitle-charts/
 # =============================================================================
 
+# Default image repositories (reference values for proxy-rewrite logic in _helpers.tpl).
+# IMPORTANT: These must match the actual defaults below at agent.image.repository
+# and datadog.image.repository. If you change those values, update these too.
+_defaults:
+  agentImageRepository: ghcr.io/anycred/entitle-agent  # Must match agent.image.repository below
+  datadogImageRepository: gcr.io/datadoghq/agent        # Must match datadog.image.repository below
+
 # -- imageCredentials: Base64-encoded dockerconfigjson for the agent image registry.
 # Typically auto-extracted from agent.token (the token blob contains this field).
 # Only set explicitly if you need to override the registry credentials in the token.
@@ -97,6 +104,7 @@ agent:
     key: "ENTITLE_JSON_CONFIGURATION"     # Key within the Secret (override if your secret uses a different key)
 
   image:
+    # IMPORTANT: This default must match _defaults.agentImageRepository at the top of this file.
     repository: ghcr.io/anycred/entitle-agent  # Docker image repository. Override to mirror into a private registry (e.g. myreg.example.com/mirrors/entitle-agent).
     tag: latest            # Tag for the agent image; defaults to Chart.appVersion if empty
 
@@ -132,8 +140,10 @@ datadog:
 
   # Datadog logs sidecar image. Override `repository` to mirror into a private
   # registry (e.g. myreg.example.com/mirrors/datadog-agent).
-  # When routing v1 is active, the repository is rewritten at render time to
-  # pull through the on-prem registry proxy (the tag is preserved).
+  # When routing v1 is active and using the default repository, the image is
+  # rewritten to pull through the on-prem registry proxy (the tag is preserved).
+  # Custom repositories bypass the proxy to allow direct pulls from private mirrors.
+  # IMPORTANT: The repository default must match _defaults.datadogImageRepository at the top of this file.
   image:
     repository: gcr.io/datadoghq/agent
     tag: latest


### PR DESCRIPTION
… tokens

Modified both `agentImageRepository` and `datadogImage` helpers to only apply proxy rewriting when the repository value is the default. When a customer explicitly sets a custom repository (e.g., a private mirror), the helpers now use it as-is instead of forcing it through the proxy.

Before:
- Default repository + routing v1 → proxy rewrite ✓
- Custom repository + routing v1 → proxy rewrite (broken!)

After:
- Default repository + routing v1 → proxy rewrite ✓
- Custom repository + routing v1 → use as-is (fixed!)

This allows customers with routing v1 tokens to actually use the configurable image feature to pull from private mirrors, which was the original intent of the feature but was blocked by the unconditional proxy rewrite logic.

Defaults checked:
- agent.image.repository: ghcr.io/anycred/entitle-agent
- datadog.image.repository: gcr.io/datadoghq/agent