### PR TITLE
fix(entitle-agent): don't re-key secretRef pull secret to proxy host (DOPS-678)

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -18,7 +18,12 @@ icon: https://app.entitle.io/favicon.ico
 # v2.8.0 (DOPS-678): also pull the agent image through the proxy (routing v1+), keyed
 # to the proxy host; the agent and monitoring-agent images share one proxy URL.
 # v2.8.1: remove the ci/ test scaffolding (no chart behavior change).
-version: 2.8.1
+# v2.8.2 (DOPS-678): fix 401 ImagePullBackOff on the agent.secretRef + routing v1
+# path. The secretRef path can't rewrite the Deployment image to the proxy host
+# (token is opaque at render time), so the extract-pull-secret hook no longer
+# re-keys the pull secret to the proxy host — it keeps the token's imageCredentials
+# keyed to the upstream registry host that the un-rewritten image is pulled from.
+version: 2.8.2
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/hook-extract-job.yaml
+++ b/charts/entitle-agent/templates/hook-extract-job.yaml
@@ -60,22 +60,12 @@ spec:
           {{- if not (or .Values.imagePullSecret.name $hasImageCreds) }}
           IMAGE_CREDS=$(echo "$FULL_TOKEN" | jq -r '.imageCredentials // empty')
 
-          # routing v1+ pulls the agent image through the proxy host, so the pull
-          # secret must be keyed to that host instead of the upstream registry
-          # (mirrors entitle-agent.dockerConfigJson for the render-time token path).
-          ROUTING=$(echo "$FULL_TOKEN" | jq -r '.routing // empty')
-          PLATFORM=$(echo "$FULL_TOKEN" | jq -r '.platform // empty')
-          if [ -n "$IMAGE_CREDS" ] && [ -n "$ROUTING" ] && [ "$ROUTING" != "v0" ] && [ -n "$PLATFORM" ]; then
-            case "$PLATFORM" in
-              dev-*) PROXY_HOST="agent-${PLATFORM#dev-}.dev.entitle.io" ;;
-              *)     PROXY_HOST="agent.${PLATFORM}.entitle.io" ;;
-            esac
-            echo "routing=$ROUTING: re-keying pull secret to proxy host $PROXY_HOST"
-            IMAGE_CREDS=$(echo "$IMAGE_CREDS" | base64 -d \
-              | jq -c --arg h "$PROXY_HOST" '{auths: (.auths | to_entries | map(.key = $h) | from_entries)}' \
-              | base64 -w0)
-          fi
-
+          # Unlike the render-time token path, the secretRef path cannot rewrite
+          # the Deployment image to the proxy host: the token is opaque at render
+          # time and this hook runs before the Deployment exists. The agent image
+          # is therefore pulled directly from agent.image.repository (its upstream
+          # host), so the pull secret must stay keyed to that upstream host —
+          # patch the token's imageCredentials through unchanged.
           if [ -n "$IMAGE_CREDS" ]; then
             echo "Patching docker-login secret with extracted imageCredentials"
             kubectl patch secret "{{ include "entitle-agent.fullname" . }}-docker-login" \


### PR DESCRIPTION
## Problem

The `secretref / test (v1)` job in the [entitle-agent chart test suite](https://github.com/anycred/entitle-charts-tests/actions/runs/29020926174) fails: the agent pod stays `Init:ImagePullBackOff` pulling `ghcr.io/anycred/entitle-agent-qa:latest` with a **401 Unauthorized** (anonymous token) — even though the `docker-login` secret exists and `imagePullSecrets` is correctly wired.

## Root cause

Two code paths provision the image pull:

- **Render-time token path** (`set-token`, `inline-token`): the token is available at `helm template` time, so `entitle-agent.agentImageRepository` rewrites the **image** host to the proxy host and `entitle-agent.dockerConfigJson` re-keys the **pull secret** to the *same* proxy host. Both match → pull works.
- **secretRef path** (`secretref`): the token lives in a pre-existing Secret and is **opaque at render time**. The Deployment image therefore can't be rewritten and stays on its upstream host (`ghcr.io`). But the `extract-pull-secret` hook read the token at runtime, saw `routing=v1`, and **re-keyed the pull secret to the proxy host**.

Result: image host = `ghcr.io`, pull-secret host = `agent.<platform>.entitle.io` → kubelet has no credentials for `ghcr.io` → anonymous pull → 401.

The re-key can't be made consistent in the secretRef path: the hook runs *before* the Deployment exists, so it can't rewrite the image to match. (`secretref-registry/v1` passed because the test builds the registry secret from the token's `imageCredentials` un-rewritten; `secretref/v0` passed because the re-key is skipped for v0.)

## Fix

Drop the proxy re-key in the `extract-pull-secret` hook. The secretRef path pulls the agent image directly from `agent.image.repository` (its upstream host), so the pull secret stays keyed to that host — the token's `imageCredentials` are patched through unchanged (same as the v0 path already did).

## Verification

Dispatched the test orchestrator against this branch — **all 8 jobs green**, including the previously-failing `secretref / test (v1)`:
https://github.com/anycred/entitle-charts-tests/actions/runs/29037900565

Chart bumped `2.8.1` → `2.8.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
