### PR TITLE
feat: add ENTITLE_EXPLICITLY_SET_IMAGE_CREDENTIALS_HASH env var

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -30,7 +30,9 @@ icon: https://app.entitle.io/favicon.ico
 # to the proxy host; the agent and monitoring-agent images share one proxy URL.
 # v2.9.1: Remove _defaults from values.yaml - it was internal chart logic that
 # caused --reuse-values upgrade failures. Templates now use hardcoded defaults.
-version: 2.9.1
+# v2.10.0: Add ENTITLE_EXPLICITLY_SET_IMAGE_CREDENTIALS_HASH env var - SHA256 hash
+# of explicitly set imageCredentials (not extracted from token).
+version: 2.10.0
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -387,6 +387,10 @@ healthcheck init container so validators run with identical configuration.
       name: {{ include "entitle-agent.agentSecretName" . }}
       key: {{ include "entitle-agent.agentSecretKey" . }}
       optional: false
+{{- if and .Values.imageCredentials (ne .Values.imageCredentials "") (ne .Values.imageCredentials "MISSING_CUSTOMER_DATA") }}
+- name: ENTITLE_EXPLICITLY_SET_IMAGE_CREDENTIALS_HASH
+  value: {{ .Values.imageCredentials | sha256sum | quote }}
+{{- end }}
 {{- if eq .Values.platform.mode "azure" }}
 - name: AZURE_KEY_VAULT_NAME
   value: {{ .Values.platform.azure.keyVaultName }}


### PR DESCRIPTION
## Summary

Adds a new environment variable `ENTITLE_EXPLICITLY_SET_IMAGE_CREDENTIALS_HASH` that contains the SHA256 hash of explicitly set image credentials.

## Behavior

The env var is **only set** when `imageCredentials` is:
- Explicitly provided via `--set imageCredentials=...` or in values.yaml
- Not empty
- Not the placeholder `"MISSING_CUSTOMER_DATA"`

The env var is **NOT set** when:
- `imageCredentials` is auto-extracted from `agent.token`
- `imageCredentials` is not provided at all

## Use Case

Allows the agent to:
- Detect when image credentials have been explicitly configured
- Track credential hash for monitoring/audit purposes
- Distinguish between explicit credentials vs. token-embedded credentials

## Changes

- Added `ENTITLE_EXPLICITLY_SET_IMAGE_CREDENTIALS_HASH` env var in `entitle-agent.agentEnv` helper
- Chart version bumped to **2.10.0**
- Uses SHA256 hash of the `imageCredentials` value

## Testing

✅ **Test 1: Explicit imageCredentials**
```bash
--set imageCredentials="<base64>"
```
**Result:** Env var present with SHA256 hash
```
ENTITLE_EXPLICITLY_SET_IMAGE_CREDENTIALS_HASH: a3e9c2b9b4cda30986d946240f4dba4d83e29c2aa263ccb66fda631adb4b5245
```

✅ **Test 2: Auto-extracted from token**
```bash
--set agent.token="<nextgen-token-with-embedded-credentials>"
```
**Result:** Env var NOT present (correct - credentials not explicitly set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)