### PR TITLE
fix: safe access to datadog.image fields for --reuse-values upgrades from pre-v2.8.0

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -34,7 +34,9 @@ icon: https://app.entitle.io/favicon.ico
 # agent.secretRef.name and imagePullSecret.name (introduced in v2.0.0).
 # v2.10.0: Add ENTITLE_EXPLICITLY_SET_IMAGE_CREDENTIALS_HASH env var - SHA256 hash
 # of explicitly set imageCredentials (not extracted from token).
-version: 2.10.0
+# v2.10.1: Fix --reuse-values upgrades from pre-v2.8.0 releases - safely access
+# datadog.image.repository/tag (introduced in v2.8.0) in the datadogImage helper.
+version: 2.10.1
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -47,6 +47,32 @@ Use this instead of direct .Values.imagePullSecret.name access.
 {{- end -}}
 
 {{/*
+Safe accessor for datadog.image.repository — falls back to the chart default
+when the datadog.image block is absent (introduced in v2.8.0; missing on
+--reuse-values upgrades from older releases).
+Use this instead of direct .Values.datadog.image.repository access.
+*/}}
+{{- define "entitle-agent.datadogImageRepositoryValue" -}}
+{{- if hasKey .Values.datadog "image" -}}
+{{- .Values.datadog.image.repository | default (include "entitle-agent.defaultDatadogRepository" .) -}}
+{{- else -}}
+{{- include "entitle-agent.defaultDatadogRepository" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Safe accessor for datadog.image.tag — returns "latest" if not set.
+Use this instead of direct .Values.datadog.image.tag access.
+*/}}
+{{- define "entitle-agent.datadogImageTagValue" -}}
+{{- if hasKey .Values.datadog "image" -}}
+{{- .Values.datadog.image.tag | default "latest" -}}
+{{- else -}}
+{{- "latest" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "entitle-agent.name" -}}
@@ -278,8 +304,8 @@ Docs: https://docs.beyondtrust.com/entitle/docs/entitle-agent
                              If a custom (non-default) repository is explicitly configured,
                              use it as-is to allow direct pulls from private mirrors. */}}
 {{- define "entitle-agent.datadogImage" -}}
-  {{- $repository := .Values.datadog.image.repository -}}
-  {{- $tag := .Values.datadog.image.tag | default "latest" -}}
+  {{- $repository := include "entitle-agent.datadogImageRepositoryValue" . -}}
+  {{- $tag := include "entitle-agent.datadogImageTagValue" . -}}
   {{- $routing := include "entitle-agent.extractedRouting" . | trim -}}
   {{- $proxyUrl := include "entitle-agent.proxyUrl" . -}}
   {{- $defaultDatadogRepo := include "entitle-agent.defaultDatadogRepository" . -}}

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -137,6 +137,9 @@ datadog:
   # rewritten to pull through the on-prem registry proxy (the tag is preserved).
   # Custom repositories bypass the proxy to allow direct pulls from private mirrors.
   # IMPORTANT: The repository default must match entitle-agent.defaultDatadogRepository in templates/_helpers.tpl.
+  # IMPORTANT: The tag default must match the "latest" fallback in entitle-agent.datadogImageTagValue in templates/_helpers.tpl.
+  # When this block is absent from the release values (--reuse-values upgrades from pre-v2.8.0),
+  # the entitle-agent.datadogImageRepositoryValue/TagValue safe accessors fall back to these same defaults.
   image:
     repository: gcr.io/datadoghq/agent
     tag: latest


### PR DESCRIPTION
## What

`helm upgrade --reuse-values` from a release older than v2.8.0 fails with:

```
Error: UPGRADE FAILED: template: entitle-agent/templates/deployment.yaml:48:18: executing "entitle-agent/templates/deployment.yaml" at <include "entitle-agent.datadogImage" .>: error calling include: template: entitle-agent/templates/_helpers.tpl:281:28: executing "entitle-agent.datadogImage" at <.Values.datadog.image.repository>: nil pointer evaluating interface {}.repository
```

The `entitle-agent.datadogImage` helper dereferences `.Values.datadog.image.repository` directly, but the `datadog.image` block was only introduced in v2.8.0 (#67) — with `--reuse-values`, the new chart's defaults are not merged, so the block is absent and the lookup hits a nil map.

## How

Same pattern as #73 (v2.9.2, `agent.secretRef` / `imagePullSecret`):

- Add `entitle-agent.datadogImageRepositoryValue` / `entitle-agent.datadogImageTagValue` safe accessors guarded by `hasKey`, and use them in `datadogImage`.
- The repository fallback is `include "entitle-agent.defaultDatadogRepository"` (not a literal) so the routing-v1 proxy-rewrite equality check (`$isDefault`) still matches — a v1.x-upgraded release renders the exact image a fresh default install would.
- Cross-reference comments added above `datadog.image` in `values.yaml`; chart version bumped to 2.10.1.

## Testing

Reproduced and verified on minikube:
1. Clean install of published chart 1.1.0 (Datadog sidecar mode, QA token).
2. `helm upgrade --reuse-values --set imageCredentials=...` with published 2.10.0 → nil pointer (repro).
3. Same upgrade with this branch → succeeds; rollout completes 3/3, sidecar renders `gcr.io/datadoghq/agent:latest`, no Datadog DaemonSet (sidecar mode preserved), agent image untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)