### PR TITLE
fix: nil pointer in serviceAccountAnnotations for platform.mode=gcp --reuse-values upgrades

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -36,7 +36,10 @@ icon: https://app.entitle.io/favicon.ico
 # of explicitly set imageCredentials (not extracted from token).
 # v2.10.1: Fix --reuse-values upgrades from pre-v2.8.0 releases - safely access
 # datadog.image.repository/tag (introduced in v2.8.0) in the datadogImage helper.
-version: 2.10.1
+# v2.10.2: Fix nil pointer in serviceAccountAnnotations when platform.mode=gcp on
+# --reuse-values upgrades from releases without a platform.gke block (e.g. v1.1.0):
+# `default` evaluates eagerly, so the gke fallback now goes through safe accessors.
+version: 2.10.2
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -73,6 +73,33 @@ Use this instead of direct .Values.datadog.image.tag access.
 {{- end -}}
 
 {{/*
+Safe accessor for platform.gke.serviceAccount — returns empty string when the
+deprecated platform.gke block is absent (e.g. --reuse-values upgrades from
+releases that only had platform.gcp, like v1.1.0). `default` evaluates its
+arguments eagerly, so the fallback must not dereference platform.gke directly.
+Use this instead of direct .Values.platform.gke.serviceAccount access.
+*/}}
+{{- define "entitle-agent.gkeServiceAccountValue" -}}
+{{- if hasKey .Values.platform "gke" -}}
+{{- .Values.platform.gke.serviceAccount | default "" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Safe accessor for platform.gke.projectId — returns empty string if not set.
+Use this instead of direct .Values.platform.gke.projectId access.
+*/}}
+{{- define "entitle-agent.gkeProjectIdValue" -}}
+{{- if hasKey .Values.platform "gke" -}}
+{{- .Values.platform.gke.projectId | default "" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "entitle-agent.name" -}}
@@ -141,8 +168,8 @@ based on platform.mode.
 {{- if eq .Values.platform.mode "aws" -}}
 eks.amazonaws.com/role-arn: {{ .Values.platform.aws.iamRole }}
 {{- else if eq .Values.platform.mode "gcp" }}
-{{- $gcpSA := .Values.platform.gcp.serviceAccount | default .Values.platform.gke.serviceAccount }}
-{{- $gcpProject := .Values.platform.gcp.projectId | default .Values.platform.gke.projectId }}
+{{- $gcpSA := .Values.platform.gcp.serviceAccount | default (include "entitle-agent.gkeServiceAccountValue" .) }}
+{{- $gcpProject := .Values.platform.gcp.projectId | default (include "entitle-agent.gkeProjectIdValue" .) }}
 iam.gke.io/gcp-service-account: {{ printf "%s@%s.iam.gserviceaccount.com" $gcpSA $gcpProject | quote}}
 {{- else if eq .Values.platform.mode "azure" }}
 azure.workload.identity/client-id: {{ .Values.platform.azure.clientId }}

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -31,6 +31,9 @@ platform:
     projectId: ""         # GCP project ID
   # -- gke: Deprecated alias for gcp. Use platform.gcp instead.
   # Kept for backward compatibility — if platform.gcp values are empty, falls back to gke.
+  # When this block is absent from the release values (--reuse-values upgrades from releases
+  # that only had platform.gcp, like v1.1.0), the entitle-agent.gkeServiceAccountValue/
+  # gkeProjectIdValue safe accessors in templates/_helpers.tpl fall back to empty strings.
   gke:
     serviceAccount: ""
     projectId: ""


### PR DESCRIPTION
## What

When `platform.mode == "gcp"`, `--reuse-values` upgrades from releases without a `platform.gke` block (e.g. v1.1.0, which only had `platform.gcp`) fail to render:

```
nil pointer evaluating interface {}.serviceAccount
```

Found during the safe-accessor audit of all value paths added since chart 1.1.0 (follow-up to #75). Every other post-1.1.0 path is already covered (#73, #75); this was the last gap.

## Root cause

`entitle-agent.serviceAccountAnnotations` (gcp branch):

```
{{- $gcpSA := .Values.platform.gcp.serviceAccount | default .Values.platform.gke.serviceAccount }}
```

Go templates evaluate `default`'s arguments **eagerly** (no short-circuit), so the deprecated `platform.gke` fallback is dereferenced even when `platform.gcp.serviceAccount` is set — hitting exactly the customers who configured everything correctly. Fresh installs are protected only by the empty-string `gke` stub in values.yaml, which `--reuse-values` upgrades never receive.

(The `gke` fallback exists for 1.2.x users who set `platform.gke.*` manually to work around 1.2.2's template reading `gke` while its values defined `gcp`.)

## How

Same `hasKey` safe-accessor pattern as v2.9.2 (#73) and v2.10.1 (#75):

- Add `entitle-agent.gkeServiceAccountValue` / `entitle-agent.gkeProjectIdValue` (empty-string fallback) and use them as the `default` fallback — an `include` of a guarded helper is safe in the eager argument position.
- Cross-reference comment above the `gke` stub in `values.yaml`; chart version bumped to 2.10.2.

## Testing

Via `helm template` (simulating reused values by deleting the `gke` block with `gke: null`):

| Scenario | 2.10.0 (published) | This branch |
|---|---|---|
| `mode=gcp`, gcp set, no `gke` block (v1.1.0 upgrade) | nil pointer | `iam.gke.io/gcp-service-account: "my-sa@my-project.iam.gserviceaccount.com"` |
| `mode=gcp`, gcp empty, `gke` set (1.2.x workaround users) | — | falls back: `"legacy-sa@legacy-project.iam.gserviceaccount.com"` |
| default values, `mode=native` | — | renders OK |

🤖 Generated with [Claude Code](https://claude.com/claude-code)