### PR TITLE
fix: nil pointer on platform.gcp for --reuse-values upgrades from v1.0.x

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -39,7 +39,10 @@ icon: https://app.entitle.io/favicon.ico
 # v2.10.2: Fix nil pointer in serviceAccountAnnotations when platform.mode=gcp on
 # --reuse-values upgrades from releases without a platform.gke block (e.g. v1.1.0):
 # `default` evaluates eagerly, so the gke fallback now goes through safe accessors.
-version: 2.10.2
+# v2.10.3: Same fix for the platform.gcp side - the oldest versions (v1.0.x) had no
+# platform.gcp block and defaulted platform.mode to "gcp" for every install, so
+# --reuse-values upgrades from v1.0.x nil-panicked on .Values.platform.gcp.serviceAccount.
+version: 2.10.3
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -100,6 +100,32 @@ Use this instead of direct .Values.platform.gke.projectId access.
 {{- end -}}
 
 {{/*
+Safe accessor for platform.gcp.serviceAccount — returns empty string when the
+platform.gcp block is absent (--reuse-values upgrades from v1.0.x, which only
+had platform.gke and defaulted platform.mode to "gcp" for every install).
+Use this instead of direct .Values.platform.gcp.serviceAccount access.
+*/}}
+{{- define "entitle-agent.gcpServiceAccountValue" -}}
+{{- if hasKey .Values.platform "gcp" -}}
+{{- .Values.platform.gcp.serviceAccount | default "" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Safe accessor for platform.gcp.projectId — returns empty string if not set.
+Use this instead of direct .Values.platform.gcp.projectId access.
+*/}}
+{{- define "entitle-agent.gcpProjectIdValue" -}}
+{{- if hasKey .Values.platform "gcp" -}}
+{{- .Values.platform.gcp.projectId | default "" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "entitle-agent.name" -}}
@@ -168,8 +194,8 @@ based on platform.mode.
 {{- if eq .Values.platform.mode "aws" -}}
 eks.amazonaws.com/role-arn: {{ .Values.platform.aws.iamRole }}
 {{- else if eq .Values.platform.mode "gcp" }}
-{{- $gcpSA := .Values.platform.gcp.serviceAccount | default (include "entitle-agent.gkeServiceAccountValue" .) }}
-{{- $gcpProject := .Values.platform.gcp.projectId | default (include "entitle-agent.gkeProjectIdValue" .) }}
+{{- $gcpSA := (include "entitle-agent.gcpServiceAccountValue" .) | default (include "entitle-agent.gkeServiceAccountValue" .) }}
+{{- $gcpProject := (include "entitle-agent.gcpProjectIdValue" .) | default (include "entitle-agent.gkeProjectIdValue" .) }}
 iam.gke.io/gcp-service-account: {{ printf "%s@%s.iam.gserviceaccount.com" $gcpSA $gcpProject | quote}}
 {{- else if eq .Values.platform.mode "azure" }}
 azure.workload.identity/client-id: {{ .Values.platform.azure.clientId }}

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -26,6 +26,9 @@ platform:
   mode: "native"
   aws:
     iamRole: ""           # IAM role ARN for the agent's IRSA service account annotation
+  # When this block is absent from the release values (--reuse-values upgrades from v1.0.x,
+  # which only had platform.gke), the entitle-agent.gcpServiceAccountValue/gcpProjectIdValue
+  # safe accessors in templates/_helpers.tpl fall back to empty strings.
   gcp:
     serviceAccount: ""    # GKE service account name (without @project.iam.gserviceaccount.com)
     projectId: ""         # GCP project ID


### PR DESCRIPTION
## What

Completes the safe-accessor coverage started in #75/#76. `--reuse-values` upgrades from the oldest chart versions (v1.0.x, Nov 2022) fail to render when `platform.mode == "gcp"`:

```
nil pointer evaluating interface {}.serviceAccount
```

## Who hits this

Broader than GKE customers: **v1.0.x defaulted `platform.mode: gcp` for every install** (and its templates never read `mode`, so nobody noticed). Any customer whose release lineage starts at v1.0.x and only ever upgraded with `--reuse-values` carries `mode=gcp` with no `platform.gcp` block — the first `--reuse-values` upgrade bakes the v1.0.x defaults into the release config permanently, and later chart defaults never merge in.

## Root cause

`serviceAccountAnnotations` (gcp branch): #76 guarded the `gke` **fallback** side of `gcp | default gke`, but the **primary** `.Values.platform.gcp.serviceAccount` dereference was still bare — v1.0.x values have `platform.gke` only, so the primary side panics (`default` evaluates both arguments eagerly).

## How

Add `entitle-agent.gcpServiceAccountValue` / `entitle-agent.gcpProjectIdValue` (`hasKey`-guarded, empty-string fallback) — both sides of the fallback now go through safe accessors. Chart version bumped to 2.10.3.

## Testing

Via `helm template` with simulated v1.0.0 release values (`mode: gcp`, `gke` block only, no `agent.token`, `gcp: null` to defeat coalescing):

| Scenario | 2.10.0 (published) | This branch |
|---|---|---|
| 2022 GKE customer (`gke.*` set, no `gcp` block) | nil pointer | `"legacy-sa@legacy-project.iam.gserviceaccount.com"` via the gke fallback |
| Accidental `mode: gcp` customer (never touched platform) | nil pointer | `"@.iam.gserviceaccount.com"` — byte-identical to what v1.0.x rendered for them |
| Modern `mode=gcp`, `gcp.*` set | — | `"modern-sa@modern-project..."` — gcp wins over fallback |
| Default values, `mode=native` | — | renders OK |

🤖 Generated with [Claude Code](https://claude.com/claude-code)