### PR TITLE
feat: ICH-5042 native custom CA bundle support (Secret/ConfigMap mount + ENTITLE_CUSTOM_CA_CERT_PATH)

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -42,7 +42,11 @@ icon: https://app.entitle.io/favicon.ico
 # v2.10.3: Same fix for the platform.gcp side - the oldest versions (v1.0.x) had no
 # platform.gcp block and defaulted platform.mode to "gcp" for every install, so
 # --reuse-values upgrades from v1.0.x nil-panicked on .Values.platform.gcp.serviceAccount.
-version: 2.10.3
+# v2.11.0 (ICH-5042): native custom CA bundle support - mount a combined PEM bundle
+# (public CAs + enterprise CA) from a pre-existing Secret or ConfigMap via customCa.*
+# values and set ENTITLE_CUSTOM_CA_CERT_PATH (agent >= 26.03.2), replacing the manual
+# Deployment edit that was wiped on every helm upgrade (SUP-259/SUP-538).
+version: 2.11.0
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -42,10 +42,8 @@ icon: https://app.entitle.io/favicon.ico
 # v2.10.3: Same fix for the platform.gcp side - the oldest versions (v1.0.x) had no
 # platform.gcp block and defaulted platform.mode to "gcp" for every install, so
 # --reuse-values upgrades from v1.0.x nil-panicked on .Values.platform.gcp.serviceAccount.
-# v2.11.0 (ICH-5042): native custom CA bundle support - mount a combined PEM bundle
-# (public CAs + enterprise CA) from a pre-existing Secret or ConfigMap via customCa.*
-# values and set ENTITLE_CUSTOM_CA_CERT_PATH (agent >= 26.03.2), replacing the manual
-# Deployment edit that was wiped on every helm upgrade (SUP-259/SUP-538).
+# v2.11.0 (ICH-5042): customCa.* values mount a combined CA bundle from a Secret/ConfigMap
+# and set ENTITLE_CUSTOM_CA_CERT_PATH, so custom CA trust survives helm upgrade.
 version: 2.11.0
 appVersion: "1.0.0"
 

--- a/charts/entitle-agent/README.md
+++ b/charts/entitle-agent/README.md
@@ -532,6 +532,9 @@ The following table lists the configurable parameters of the Entitle-agent chart
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|-----------------------------------|
 | `imageCredentials`               | Base64-encoded dockerconfigjson. **Optional** — auto-extracted from `agent.token` if not set.                                                                    | `"MISSING_CUSTOMER_DATA"`         | `false`                           |
 | `imagePullSecret.name`           | Name of existing `kubernetes.io/dockerconfigjson` Secret for image pull.                                                                                         | `""`                              | `false`                           |
+| `customCa.secretName`            | Name of a pre-existing Secret holding a combined CA bundle to trust (see [Custom CA bundle](#custom-ca-bundle)). Mutually exclusive with `customCa.configMapName`. | `""`                              | `false`                           |
+| `customCa.configMapName`         | Name of a pre-existing ConfigMap holding a combined CA bundle to trust. Mutually exclusive with `customCa.secretName`.                                           | `""`                              | `false`                           |
+| `customCa.key`                   | Key within the Secret/ConfigMap that holds the combined PEM bundle.                                                                                              | `"ca-bundle.pem"`                 | `false`                           |
 | `kmsType`                        | KMS for agent to save secrets. Values: `kubernetes_secret_manager`, `aws_secret_manager`, `gcp_secret_manager`, `azure_secret_manager`, `hashicorp_vault`        | `"kubernetes_secret_manager"`     | `true`                            |
 | `platform.mode`                  | Cloud platform. Values: `native`, `aws`, `gcp`, `azure`                                                                                                         | `"native"`                        | `true`                            |
 | `platform.aws.iamRole`           | IAM role ARN for agent's IRSA service account annotation                                                                                                         | `""`                              | `true` if `platform.mode="aws"`   |
@@ -561,3 +564,29 @@ The following table lists the configurable parameters of the Entitle-agent chart
 | `datadog.datadog.apiKey`         | Datadog API key                                                                                                                                                  | `""`                              | `false`                           |
 | `datadog.datadog.tags`           | Datadog tags (https://docs.datadoghq.com/tagging/)                                                                                                               | `[]`                              | `false`                           |
 | `datadog.providers.gke.autopilot`| Whether to enable GKE autopilot mode                                                                                                                             | `false`                           | `false`                           |
+
+## Custom CA bundle
+
+If the agent's outbound TLS is intercepted by an enterprise proxy, or it must reach services signed by a private CA, mount a custom CA bundle via chart values and the agent (version **26.03.2+**) will trust it for all outbound connections (Kafka, remote settings, integrations).
+
+**IMPORTANT**: the bundle must be a **combined** PEM file — the standard public CAs **plus** your enterprise CA concatenated. The agent points its entire trust store at this file (it does not append to the system store), so a file containing only the enterprise CA breaks trust for public endpoints.
+
+1. Build the combined bundle (on any Linux host with system CA certs):
+    ```shell
+    cat /etc/ssl/certs/ca-certificates.crt my-enterprise-ca.pem > ca-bundle.pem
+    ```
+2. Create a Secret **or** ConfigMap from it in the agent's namespace:
+    ```shell
+    kubectl create secret generic entitle-custom-ca --from-file=ca-bundle.pem -n ${NAMESPACE}
+    # or:
+    kubectl create configmap entitle-custom-ca --from-file=ca-bundle.pem -n ${NAMESPACE}
+    ```
+3. Point the chart at it (set exactly one of the two):
+    ```shell
+    --set customCa.secretName=entitle-custom-ca
+    # or:
+    --set customCa.configMapName=entitle-custom-ca
+    ```
+    If your Secret/ConfigMap uses a key other than `ca-bundle.pem`, also set `customCa.key`.
+
+The chart mounts the bundle read-only at `/etc/entitle/custom-ca/<key>` and sets the `ENTITLE_CUSTOM_CA_CERT_PATH` env var automatically, so the configuration survives `helm upgrade` (no manual Deployment edits needed).

--- a/charts/entitle-agent/README.md
+++ b/charts/entitle-agent/README.md
@@ -567,7 +567,7 @@ The following table lists the configurable parameters of the Entitle-agent chart
 
 ## Custom CA bundle
 
-If the agent's outbound TLS is intercepted by an enterprise proxy, or it must reach services signed by a private CA, mount a custom CA bundle via chart values and the agent (version **26.03.2+**) will trust it for all outbound connections (Kafka, remote settings, integrations).
+If the agent's outbound TLS is intercepted by an enterprise proxy, or it must reach services signed by a private CA, mount a custom CA bundle via chart values and the agent (image version **2.9.10+**) will trust it for all outbound connections (Kafka, remote settings, integrations).
 
 **IMPORTANT**: the bundle must be a **combined** PEM file — the standard public CAs **plus** your enterprise CA concatenated. The agent points its entire trust store at this file (it does not append to the system store), so a file containing only the enterprise CA breaks trust for public endpoints.
 

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -130,9 +130,7 @@ Use this instead of direct .Values.platform.gcp.projectId access.
      ============================================================ */}}
 
 {{/*
-Safe accessor for customCa.secretName — returns empty string when the customCa
-block is absent (--reuse-values upgrades from releases older than v2.11.0).
-Use this instead of direct .Values.customCa.secretName access.
+Safe accessor for customCa.secretName — empty when the block is absent (pre-v2.11.0 --reuse-values).
 */}}
 {{- define "entitle-agent.customCaSecretNameValue" -}}
 {{- if hasKey .Values "customCa" -}}
@@ -143,8 +141,7 @@ Use this instead of direct .Values.customCa.secretName access.
 {{- end -}}
 
 {{/*
-Safe accessor for customCa.configMapName — returns empty string if not set.
-Use this instead of direct .Values.customCa.configMapName access.
+Safe accessor for customCa.configMapName — empty if not set.
 */}}
 {{- define "entitle-agent.customCaConfigMapNameValue" -}}
 {{- if hasKey .Values "customCa" -}}
@@ -155,8 +152,7 @@ Use this instead of direct .Values.customCa.configMapName access.
 {{- end -}}
 
 {{/*
-Safe accessor for customCa.key — falls back to "ca-bundle.pem" if not set.
-Use this instead of direct .Values.customCa.key access.
+Safe accessor for customCa.key — defaults to "ca-bundle.pem".
 */}}
 {{- define "entitle-agent.customCaKeyValue" -}}
 {{- if hasKey .Values "customCa" -}}
@@ -167,7 +163,7 @@ Use this instead of direct .Values.customCa.key access.
 {{- end -}}
 
 {{/*
-Whether custom CA support is enabled — truthy when either source is set.
+Truthy when either custom CA source is set.
 */}}
 {{- define "entitle-agent.customCaEnabled" -}}
 {{- if or (include "entitle-agent.customCaSecretNameValue" .) (include "entitle-agent.customCaConfigMapNameValue" .) -}}
@@ -176,21 +172,21 @@ true
 {{- end -}}
 
 {{/*
-Directory where the custom CA bundle is mounted in the agent containers.
+Mount directory for the custom CA bundle.
 */}}
 {{- define "entitle-agent.customCaMountPath" -}}
 /etc/entitle/custom-ca
 {{- end -}}
 
 {{/*
-Full path of the mounted CA bundle file — the value of ENTITLE_CUSTOM_CA_CERT_PATH.
+Full mounted bundle path — the ENTITLE_CUSTOM_CA_CERT_PATH value.
 */}}
 {{- define "entitle-agent.customCaCertPath" -}}
 {{- printf "%s/%s" (include "entitle-agent.customCaMountPath" .) (include "entitle-agent.customCaKeyValue" .) -}}
 {{- end -}}
 
 {{/*
-Validates that at most one custom CA source is configured.
+Fails render when both custom CA sources are set.
 */}}
 {{- define "entitle-agent.validateCustomCa" -}}
 {{- if and (include "entitle-agent.customCaSecretNameValue" .) (include "entitle-agent.customCaConfigMapNameValue" .) -}}

--- a/charts/entitle-agent/templates/_helpers.tpl
+++ b/charts/entitle-agent/templates/_helpers.tpl
@@ -125,6 +125,79 @@ Use this instead of direct .Values.platform.gcp.projectId access.
 {{- end -}}
 {{- end -}}
 
+{{/* ============================================================
+     Custom CA bundle helpers (ICH-5042)
+     ============================================================ */}}
+
+{{/*
+Safe accessor for customCa.secretName — returns empty string when the customCa
+block is absent (--reuse-values upgrades from releases older than v2.11.0).
+Use this instead of direct .Values.customCa.secretName access.
+*/}}
+{{- define "entitle-agent.customCaSecretNameValue" -}}
+{{- if hasKey .Values "customCa" -}}
+{{- .Values.customCa.secretName | default "" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Safe accessor for customCa.configMapName — returns empty string if not set.
+Use this instead of direct .Values.customCa.configMapName access.
+*/}}
+{{- define "entitle-agent.customCaConfigMapNameValue" -}}
+{{- if hasKey .Values "customCa" -}}
+{{- .Values.customCa.configMapName | default "" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Safe accessor for customCa.key — falls back to "ca-bundle.pem" if not set.
+Use this instead of direct .Values.customCa.key access.
+*/}}
+{{- define "entitle-agent.customCaKeyValue" -}}
+{{- if hasKey .Values "customCa" -}}
+{{- .Values.customCa.key | default "ca-bundle.pem" -}}
+{{- else -}}
+{{- "ca-bundle.pem" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether custom CA support is enabled — truthy when either source is set.
+*/}}
+{{- define "entitle-agent.customCaEnabled" -}}
+{{- if or (include "entitle-agent.customCaSecretNameValue" .) (include "entitle-agent.customCaConfigMapNameValue" .) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Directory where the custom CA bundle is mounted in the agent containers.
+*/}}
+{{- define "entitle-agent.customCaMountPath" -}}
+/etc/entitle/custom-ca
+{{- end -}}
+
+{{/*
+Full path of the mounted CA bundle file — the value of ENTITLE_CUSTOM_CA_CERT_PATH.
+*/}}
+{{- define "entitle-agent.customCaCertPath" -}}
+{{- printf "%s/%s" (include "entitle-agent.customCaMountPath" .) (include "entitle-agent.customCaKeyValue" .) -}}
+{{- end -}}
+
+{{/*
+Validates that at most one custom CA source is configured.
+*/}}
+{{- define "entitle-agent.validateCustomCa" -}}
+{{- if and (include "entitle-agent.customCaSecretNameValue" .) (include "entitle-agent.customCaConfigMapNameValue" .) -}}
+{{- fail "entitle-agent: customCa.secretName and customCa.configMapName are mutually exclusive — set only one." -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -516,6 +589,10 @@ healthcheck init container so validators run with identical configuration.
 {{- if not .Values.datadog.enabled }}
 - name: ENTITLE_LOG_TO_FILE
   value: "true"
+{{- end }}
+{{- if include "entitle-agent.customCaEnabled" . }}
+- name: ENTITLE_CUSTOM_CA_CERT_PATH
+  value: {{ include "entitle-agent.customCaCertPath" . | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/entitle-agent/templates/deployment.yaml
+++ b/charts/entitle-agent/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- include "entitle-agent.validateAgentVersion" . -}}
 {{- include "entitle-agent.validateRequiredCredentials" . -}}
+{{- include "entitle-agent.validateCustomCa" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -95,10 +96,17 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if not .Values.datadog.enabled }}
+        {{- if or (not .Values.datadog.enabled) (include "entitle-agent.customCaEnabled" .) }}
         volumeMounts:
+        {{- if not .Values.datadog.enabled }}
           - mountPath: /var/log/entitle-agent
             name: entitle-agent-logs
+        {{- end }}
+        {{- if include "entitle-agent.customCaEnabled" . }}
+          - name: custom-ca
+            mountPath: {{ include "entitle-agent.customCaMountPath" . }}
+            readOnly: true
+        {{- end }}
         {{- end }}
       containers:
       - name: {{ include "entitle-agent.fullname" . }}
@@ -110,10 +118,17 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if not .Values.datadog.enabled }}
+        {{- if or (not .Values.datadog.enabled) (include "entitle-agent.customCaEnabled" .) }}
         volumeMounts:
+        {{- if not .Values.datadog.enabled }}
           - mountPath: /var/log/entitle-agent
             name: entitle-agent-logs
+        {{- end }}
+        {{- if include "entitle-agent.customCaEnabled" . }}
+          - name: custom-ca
+            mountPath: {{ include "entitle-agent.customCaMountPath" . }}
+            readOnly: true
+        {{- end }}
         {{- end }}
         livenessProbe:
           exec:
@@ -151,5 +166,15 @@ spec:
         - name: datadog-configmap
           configMap:
             name: {{ include "entitle-agent.fullname" . }}-datadog-config
+        {{- end }}
+        {{- if include "entitle-agent.customCaEnabled" . }}
+        - name: custom-ca
+          {{- if include "entitle-agent.customCaSecretNameValue" . }}
+          secret:
+            secretName: {{ include "entitle-agent.customCaSecretNameValue" . }}
+          {{- else }}
+          configMap:
+            name: {{ include "entitle-agent.customCaConfigMapNameValue" . }}
+          {{- end }}
         {{- end }}
       serviceAccountName: {{ include "entitle-agent.serviceAccountName" .}}

--- a/charts/entitle-agent/values.schema.json
+++ b/charts/entitle-agent/values.schema.json
@@ -34,6 +34,27 @@
         }
       }
     },
+    "customCa": {
+      "type": "object",
+      "description": "Trust a custom/enterprise CA: mount a combined PEM bundle (public CAs + enterprise CA) from a pre-existing Secret or ConfigMap and set ENTITLE_CUSTOM_CA_CERT_PATH. Set only one of secretName/configMapName. Requires agent 26.03.2+.",
+      "properties": {
+        "secretName": {
+          "type": "string",
+          "default": "",
+          "description": "Name of a pre-existing Secret holding the CA bundle. Mutually exclusive with configMapName."
+        },
+        "configMapName": {
+          "type": "string",
+          "default": "",
+          "description": "Name of a pre-existing ConfigMap holding the CA bundle. Mutually exclusive with secretName."
+        },
+        "key": {
+          "type": "string",
+          "default": "ca-bundle.pem",
+          "description": "Key within the Secret/ConfigMap that holds the combined PEM bundle."
+        }
+      }
+    },
     "externalKmsParams": {
       "type": "object",
       "properties": {

--- a/charts/entitle-agent/values.schema.json
+++ b/charts/entitle-agent/values.schema.json
@@ -36,7 +36,7 @@
     },
     "customCa": {
       "type": "object",
-      "description": "Trust a custom/enterprise CA: mount a combined PEM bundle (public CAs + enterprise CA) from a pre-existing Secret or ConfigMap and set ENTITLE_CUSTOM_CA_CERT_PATH. Set only one of secretName/configMapName. Requires agent 26.03.2+.",
+      "description": "Trust a custom/enterprise CA: mount a combined PEM bundle (public CAs + enterprise CA) from a pre-existing Secret or ConfigMap and set ENTITLE_CUSTOM_CA_CERT_PATH. Set only one of secretName/configMapName. Requires agent image 2.9.10+.",
       "properties": {
         "secretName": {
           "type": "string",

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -18,6 +18,18 @@ imagePullSecret:
   # When set, imageCredentials is ignored and no docker-login Secret is created.
   name: ""
 
+# -- customCa: Trust a custom/enterprise CA (e.g. a TLS-inspecting proxy or private CA).
+# Mounts a CA bundle from a pre-existing Secret or ConfigMap into the agent pod and
+# sets ENTITLE_CUSTOM_CA_CERT_PATH to the mounted file (requires agent 26.03.2+).
+# IMPORTANT: the bundle must be a COMBINED PEM file — the standard public CAs plus your
+# enterprise CA concatenated. The agent replaces its trust store with this file (it does
+# not append), so a bundle with only the enterprise CA breaks trust for public endpoints.
+# Set exactly one of secretName / configMapName.
+customCa:
+  secretName: ""        # Name of a pre-existing Secret holding the CA bundle
+  configMapName: ""     # Name of a pre-existing ConfigMap holding the CA bundle
+  key: "ca-bundle.pem"  # Key within the Secret/ConfigMap that holds the PEM bundle
+
 # -- platform: Cloud platform configuration.
 # Determines service account annotations for IRSA (AWS), Workload Identity (GCP/Azure).
 platform:

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -18,13 +18,10 @@ imagePullSecret:
   # When set, imageCredentials is ignored and no docker-login Secret is created.
   name: ""
 
-# -- customCa: mount a CA bundle from a pre-existing Secret or ConfigMap (set exactly one)
-# and set ENTITLE_CUSTOM_CA_CERT_PATH (agent 26.03.2+); the bundle must be COMBINED
-# (public CAs + enterprise CA) because the agent replaces its trust store with it.
 customCa:
-  secretName: ""        # Pre-existing Secret holding the bundle
-  configMapName: ""     # Pre-existing ConfigMap holding the bundle
-  key: "ca-bundle.pem"  # Key holding the PEM bundle
+  secretName: ""
+  configMapName: ""
+  key: "ca-bundle.pem"
 
 # -- platform: Cloud platform configuration.
 # Determines service account annotations for IRSA (AWS), Workload Identity (GCP/Azure).

--- a/charts/entitle-agent/values.yaml
+++ b/charts/entitle-agent/values.yaml
@@ -18,17 +18,13 @@ imagePullSecret:
   # When set, imageCredentials is ignored and no docker-login Secret is created.
   name: ""
 
-# -- customCa: Trust a custom/enterprise CA (e.g. a TLS-inspecting proxy or private CA).
-# Mounts a CA bundle from a pre-existing Secret or ConfigMap into the agent pod and
-# sets ENTITLE_CUSTOM_CA_CERT_PATH to the mounted file (requires agent 26.03.2+).
-# IMPORTANT: the bundle must be a COMBINED PEM file — the standard public CAs plus your
-# enterprise CA concatenated. The agent replaces its trust store with this file (it does
-# not append), so a bundle with only the enterprise CA breaks trust for public endpoints.
-# Set exactly one of secretName / configMapName.
+# -- customCa: mount a CA bundle from a pre-existing Secret or ConfigMap (set exactly one)
+# and set ENTITLE_CUSTOM_CA_CERT_PATH (agent 26.03.2+); the bundle must be COMBINED
+# (public CAs + enterprise CA) because the agent replaces its trust store with it.
 customCa:
-  secretName: ""        # Name of a pre-existing Secret holding the CA bundle
-  configMapName: ""     # Name of a pre-existing ConfigMap holding the CA bundle
-  key: "ca-bundle.pem"  # Key within the Secret/ConfigMap that holds the PEM bundle
+  secretName: ""        # Pre-existing Secret holding the bundle
+  configMapName: ""     # Pre-existing ConfigMap holding the bundle
+  key: "ca-bundle.pem"  # Key holding the PEM bundle
 
 # -- platform: Cloud platform configuration.
 # Determines service account annotations for IRSA (AWS), Workload Identity (GCP/Azure).


### PR DESCRIPTION
## Resolves

[ICH-5042](https://beyondtrust.atlassian.net/browse/ICH-5042) — customer cases SUP-538 (re-open), SUP-259 (original).

## Changes

- New `customCa` values block (`secretName` / `configMapName` / `key`) — mounts a customer-provided CA bundle from a pre-existing Secret **or** ConfigMap (mutually exclusive, render-time `fail` if both set) read-only at `/etc/entitle/custom-ca/<key>` and sets `ENTITLE_CUSTOM_CA_CERT_PATH` accordingly, so custom CA trust survives `helm upgrade` instead of requiring a manual Deployment edit that gets wiped.
- Env var + mount are applied to **both** the healthcheck init container and the main agent container (they share `entitle-agent.agentEnv`, so validators run with identical TLS config).
- Safe accessors with `hasKey` guards follow the chart's established `--reuse-values` pattern — upgrades from pre-2.11.0 releases (no `customCa` block in release values) render cleanly.
- `values.schema.json`: `customCa` schema added; `README.md`: parameter rows + a "Custom CA bundle" section documenting the **combined bundle** requirement (agent replaces `REQUESTS_CA_BUNDLE`/`SSL_CERT_FILE` wholesale — the file must contain public CAs + the enterprise CA) and the minimum agent version 26.03.2 (ICH-4584).
- Chart version 2.10.3 → 2.11.0.

## Verification (helm v3.21.0)

- `helm lint`: pass.
- Default render (no `customCa`) is byte-identical to master except the chart-version label/checksums.
- `--set customCa.secretName=…`: env var in both containers, read-only mounts, Secret volume.
- `--set customCa.configMapName=…`: same with ConfigMap volume.
- Both set → render fails with an actionable message.
- `--set customCa=null` (simulates `--reuse-values` from pre-2.11.0): clean render, no custom-ca artifacts.

A follow-up PR in `entitle-charts-tests` adds an e2e case (install with Secret → upgrade to ConfigMap → assert env/mount/pod-ready), covering the upgrade-persistence DOD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ICH-5042]: https://beyondtrust.atlassian.net/browse/ICH-5042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ