### PR TITLE
feat: allow the agent Role to get pods/log

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -51,7 +51,8 @@ icon: https://app.entitle.io/favicon.ico
 # (custom repos bypass the rewrite to allow direct pulls from private mirrors).
 # v2.11.0 (ICH-5042): customCa.* values mount a combined CA bundle from a Secret/ConfigMap
 # and set ENTITLE_CUSTOM_CA_CERT_PATH, so custom CA trust survives helm upgrade.
-version: 2.11.0
+# v2.12.0: the agent Role can now get pods/log.
+version: 2.12.0
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/deployment-rbac.yaml
+++ b/charts/entitle-agent/templates/deployment-rbac.yaml
@@ -50,3 +50,9 @@ rules:
       - '*'
     resources:
       - secrets
+  - verbs:
+      - get
+    apiGroups:
+      - ""
+    resources:
+      - pods/log


### PR DESCRIPTION
### What

Adds one rule to the agent's `Role`: `get` on the `pods/log` subresource (core API group).

### Why

The agent creates isolated-adapter job pods (`ich-<adapter>-<hash>-<id>`) but could not read their logs. The API rejected it:

```
pods "ich-gcp-assets-…" is forbidden: User "system:serviceaccount:entitle:entitle-agent-sa"
cannot get resource "pods/log" in API group "" in the namespace "entitle"
```

The Role granted `pods: get/list/watch`, but in RBAC a permission on a subresource is [not implied by the parent resource](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources) — `pods/log` has to be granted explicitly.

### Scope

- `get` only — `pods/log` has no list endpoint, and log streaming is `get` with `follow=true`, not `watch`.
- Appended as its own rule; no existing rule modified.
- Verified on minikube: before, `pods/log` → 403; after, → 200 with log content returned. `kubectl auth can-i --list` for the SA shows exactly one new line (`pods/log [get]`) and no other change.

### Version

`2.11.0` → `2.12.0`, with the matching one-line entry in the `Chart.yaml` history comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
