### PR TITLE
fix: ICH-5194 mount the ServiceAccount token for the agent pod

### DIFF
--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -51,10 +51,12 @@ icon: https://app.entitle.io/favicon.ico
 # (custom repos bypass the rewrite to allow direct pulls from private mirrors).
 # v2.11.0 (ICH-5042): customCa.* values mount a combined CA bundle from a Secret/ConfigMap
 # and set ENTITLE_CUSTOM_CA_CERT_PATH, so custom CA trust survives helm upgrade.
-# v2.11.1 (ICH-5194): explicitly set automountServiceAccountToken=true on the ServiceAccount
-# and the agent pod spec. Clusters that default it to false (or a policy that flips the
-# ServiceAccount) left the pod without /var/run/secrets/kubernetes.io/serviceaccount, so the
-# ServiceAccountBinding and KMS validators died with FileNotFoundError and the agent never started.
+# v2.11.1 (ICH-5194): explicitly set automountServiceAccountToken=true on the ServiceAccount,
+# the agent pod spec, and the hook ServiceAccount/Jobs. Clusters that default it to false (or a
+# policy that flips the ServiceAccount) left the pod without /var/run/secrets/kubernetes.io/serviceaccount,
+# so the ServiceAccountBinding and KMS validators died with FileNotFoundError and the agent never
+# started; the hook jobs read the same path, so helm install itself failed there too.
+# No-op wherever the field was previously unset, which is the default everywhere.
 version: 2.11.1
 appVersion: "1.0.0"
 

--- a/charts/entitle-agent/Chart.yaml
+++ b/charts/entitle-agent/Chart.yaml
@@ -51,7 +51,11 @@ icon: https://app.entitle.io/favicon.ico
 # (custom repos bypass the rewrite to allow direct pulls from private mirrors).
 # v2.11.0 (ICH-5042): customCa.* values mount a combined CA bundle from a Secret/ConfigMap
 # and set ENTITLE_CUSTOM_CA_CERT_PATH, so custom CA trust survives helm upgrade.
-version: 2.11.0
+# v2.11.1 (ICH-5194): explicitly set automountServiceAccountToken=true on the ServiceAccount
+# and the agent pod spec. Clusters that default it to false (or a policy that flips the
+# ServiceAccount) left the pod without /var/run/secrets/kubernetes.io/serviceaccount, so the
+# ServiceAccountBinding and KMS validators died with FileNotFoundError and the agent never started.
+version: 2.11.1
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/entitle-agent/templates/deployment.yaml
+++ b/charts/entitle-agent/templates/deployment.yaml
@@ -178,3 +178,5 @@ spec:
           {{- end }}
         {{- end }}
       serviceAccountName: {{ include "entitle-agent.serviceAccountName" .}}
+      # Set at pod level because it overrides the ServiceAccount setting, which a cluster policy may have forced to false.
+      automountServiceAccountToken: true

--- a/charts/entitle-agent/templates/hook-extract-job.yaml
+++ b/charts/entitle-agent/templates/hook-extract-job.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "entitle-agent.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "entitle-agent.fullname" . }}-hook
+      automountServiceAccountToken: true
       restartPolicy: Never
       containers:
       - name: extract

--- a/charts/entitle-agent/templates/hook-patch-image-job.yaml
+++ b/charts/entitle-agent/templates/hook-patch-image-job.yaml
@@ -34,6 +34,7 @@ spec:
         {{- include "entitle-agent.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "entitle-agent.fullname" . }}-hook
+      automountServiceAccountToken: true
       restartPolicy: Never
       containers:
       - name: patch-image

--- a/charts/entitle-agent/templates/hook-serviceaccount.yaml
+++ b/charts/entitle-agent/templates/hook-serviceaccount.yaml
@@ -11,4 +11,6 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
     helm.sh/hook-weight: "-10"
     helm.sh/hook-delete-policy: before-hook-creation
+# The hook jobs read /var/run/secrets/kubernetes.io/serviceaccount/namespace and call kubectl, so the token must be mounted even when the cluster default is off.
+automountServiceAccountToken: true
 {{- end }}

--- a/charts/entitle-agent/templates/service-account.yaml
+++ b/charts/entitle-agent/templates/service-account.yaml
@@ -7,3 +7,5 @@ metadata:
     {{- include "entitle-agent.serviceAccountLabels" . | nindent 4 }}
   annotations:
     {{- include "entitle-agent.serviceAccountAnnotations" . | nindent 4 }}
+# The agent reads /var/run/secrets/kubernetes.io/serviceaccount to reach the Kubernetes API, so the token must be mounted even when the cluster default is off.
+automountServiceAccountToken: true


### PR DESCRIPTION
## What

Set `automountServiceAccountToken: true` explicitly on both the agent `ServiceAccount` and the Deployment pod spec. Chart `2.11.0` → `2.11.1`.

## Why

The chart never set this field, so it inherited whatever the cluster (or an admission policy) decided. When the ServiceAccount is `automountServiceAccountToken: false`, the agent pod starts **without** `/var/run/secrets/kubernetes.io/serviceaccount`, so `KubernetesInClusterApiClient` cannot construct. Both cluster validators then fail at *init* time:

```
- initialize validator ServiceAccountBindingValidator failed - Error title: FileNotFoundError,
  Error message: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
Healthcheck failed: {'success_validators': [...], 'failed_validators': [
  {'validator': 'ServiceAccountBindingValidator', 'error_title': 'FileNotFoundError'},
  {'validator': 'KMSValidator', 'error_title': 'FileNotFoundError'}]}
```

The healthcheck exits 1, so the agent never starts and never heartbeats — the control plane just sees an agent that never appears.

Observed live on AKS `mkosoy-ich5288-aks` (agent `test-azure-cluster`, `kmsType=kubernetes_secret_manager`), failing continuously every ~6.5 min since 2026-08-02.

Note this is **not** KMS-type specific: init-time validator failures are recorded unconditionally (`utils/healthcheck/healthcheck.py:124-126`); `IGNORE_FAILURE_KMS_TYPES` only guards `validate()` failures. `azure_secret_manager` fails the same way.

## Why the pod spec (not just the ServiceAccount)

The pod-level setting overrides the ServiceAccount setting, so the agent keeps its token even if a policy flips the ServiceAccount. Verified on a live cluster:

| SA setting | Pod setting | token mounted |
|---|---|---|
| `false` | unset (chart before this PR) | ❌ |
| `false` | `true` (this PR) | ✅ |

## Verification

minikube, real agent image, ServiceAccount forced to `automountServiceAccountToken: false`:

- **before** — `success=[S3NetworkValidator]`, `failed=[KMS_Validator FileNotFoundError, KafkaNetworkValidator]`
- **after** — `success=[KubernetesServiceAccountBindingValidator, KubernetesKMSValidator, S3NetworkValidator]`, `failed=[KafkaNetworkValidator]`

`KubernetesKMSValidator` runs its full list → add → get → remove sequence and passes. The residual Kafka failure is a local-env artifact (the local token points at dev-one's in-cluster Kafka, unreachable from minikube).

Customer-facing check for a suspected case:

```
kubectl -n entitle get sa entitle-agent-sa -o jsonpath='{.automountServiceAccountToken}'
kubectl -n entitle exec deploy/entitle-agent -- ls /var/run/secrets/kubernetes.io/serviceaccount
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)